### PR TITLE
Python name mangling & identifier normalization rules

### DIFF
--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -45,6 +45,26 @@ It's represented in JSON to:
     }
 
 
+Identifier normalization
+------------------------
+
+Every identifiers (e.g. behind names) has to be normalized in JSON
+representation.  Although we recommend to use hyphens to separate words
+when declare names in Nirum code, these hyphens must be replaced by underscores
+in JSON.  The following are normalization rules:
+
+ -  Use lowercase alphabets instead of uppercases.
+ -  Use underscores instead of hyphens.
+    This rule may help to implement a runtime library for programming languages
+    disallowing hyphens for identifiers.
+
+Although all serializers must to normalize names when they serialize Nirum
+objects, we recommend deserializers to accept denormalized names as well
+to follow a [general principle of robustness][1].
+
+[1]: https://en.wikipedia.org/wiki/Robustness_principle
+
+
 Enum type
 ---------
 


### PR DESCRIPTION
- Made `Nirum.Target.Python` to use `Data.Text` using qualified import.
- Name mangling for Python target.  It follows a natural naming convention of Python: `PascalCase` for classes and `snake_case` for attributes and functions.
- Established identifier normalization rules for JSON representation.  See docs/serialization.md file.
