### PR TITLE
Make BoxedType unable to have behind name

### DIFF
--- a/src/Nirum/Parser.hs
+++ b/src/Nirum/Parser.hs
@@ -194,7 +194,8 @@ boxedTypeDeclaration :: Parser TypeDeclaration
 boxedTypeDeclaration = do
     string' "boxed" <?> "boxed type keyword"
     spaces
-    typename <- name <?> "boxed type name"
+    typename <- identifier <?> "boxed type name"
+    let name' = Name typename typename
     spaces
     char '('
     spaces
@@ -204,7 +205,7 @@ boxedTypeDeclaration = do
     spaces
     char ';'
     docs' <- optional $ try $ spaces >> (docs <?> "boed type docs")
-    return $ TypeDeclaration typename (BoxedType innerType) docs'
+    return $ TypeDeclaration name' (BoxedType innerType) docs'
 
 enumMember :: Parser EnumMember
 enumMember = do

--- a/test/Nirum/ParserSpec.hs
+++ b/test/Nirum/ParserSpec.hs
@@ -300,7 +300,7 @@ spec = do
             expectError "type path/error = text;" 1 10
 
     descTypeDecl "boxedTypeDeclaration" P.boxedTypeDeclaration $ \helpers -> do
-        let (parse', _) = helpers
+        let (parse', expectError) = helpers
         it "emits (TypeDeclaration (BoxedType ...)) if succeeded to parse" $ do
             parse' "boxed offset (float64);" `shouldBe`
                 Right (TypeDeclaration "offset" (BoxedType "float64") Nothing)
@@ -310,6 +310,8 @@ spec = do
             parse' "boxed offset (float64);\n# docs\n# docs..." `shouldBe`
                 Right (TypeDeclaration "offset" (BoxedType "float64") $
                                        Just $ Docs "docs\ndocs...\n")
+        it "cannot have behind name" $
+            expectError "boxed offset/behind (float64);" 1 13
 
     descTypeDecl "enumTypeDeclaration" P.enumTypeDeclaration $ \helpers -> do
         let (parse', expectError) = helpers


### PR DESCRIPTION
The title says it all.
