### PR TITLE
Add __nirum_boxed_type__ to serialize properly if boxed type aliased many time

### DIFF
--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -232,6 +232,8 @@ compileTypeDeclaration (TypeDeclaration typename (BoxedType itype) _) = do
 class $className:
     # TODO: docstring
 
+    __nirum_boxed_type__ = $itypeExpr
+
     def __init__(self, value: $itypeExpr) -> None:
         validate_boxed_type(value, $itypeExpr)
         self.value = value  # type: $itypeExpr


### PR DESCRIPTION
To fix spoqa/nirum-python#4, add `__nirum_boxed_type__` on boxed type in python. it have to be tested after [python runtime PR](https://github.com/spoqa/nirum-python/pull/5) merged.
