### PR TITLE
Automatically make directories if necessary

### DIFF
--- a/nirum.cabal
+++ b/nirum.cabal
@@ -57,7 +57,8 @@ test-suite spec
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   main-is:             Spec.hs
-  other-modules:       Nirum.Constructs.DeclarationSpec
+  other-modules:       Nirum.CliSpec
+               ,       Nirum.Constructs.DeclarationSpec
                ,       Nirum.Constructs.DeclarationSetSpec
                ,       Nirum.Constructs.IdentifierSpec
                ,       Nirum.Constructs.ModuleSpec

--- a/src/Nirum/Cli.hs
+++ b/src/Nirum/Cli.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE ExtendedDefaultRules, OverloadedStrings, QuasiQuotes,
              DeriveDataTypeable #-}
-module Nirum.Cli (main) where
+module Nirum.Cli (main, writeFiles) where
 
 import Control.Monad (forM_)
 import GHC.Exts (IsList(toList))
@@ -23,7 +23,8 @@ import System.Console.CmdArgs.Implicit ( Data
                                        , (&=)
                                        )
 import System.Console.CmdArgs.Default (def)
-import System.FilePath ((</>))
+import System.Directory (createDirectoryIfMissing)
+import System.FilePath (takeDirectory, (</>))
 import Text.InterpolatedString.Perl6 (qq)
 import Text.Megaparsec (Token)
 import Text.Megaparsec.Error ( Dec
@@ -94,6 +95,7 @@ writeFiles obj m =
         case result of
             Left compileError -> putStrLn [qq|error: $filePath: $compileError|]
             Right code -> do
+                createDirectoryIfMissing True $ takeDirectory filePath
                 putStrLn filePath
                 TI.writeFile filePath code
   where

--- a/test/Nirum/CliSpec.hs
+++ b/test/Nirum/CliSpec.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE OverloadedLists, OverloadedStrings #-}
+module Nirum.CliSpec where
+
+import Control.Monad (forM_)
+
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import qualified Data.Text.IO as TI
+import System.Directory (listDirectory)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Hspec.Meta
+
+import Nirum.Cli (writeFiles)
+
+expectWriteFiles :: FilePath -> [(FilePath, Text)] -> IO [FilePath]
+expectWriteFiles tmpDir files = do
+    writeFiles tmpDir $ M.fromList [(f, Right c) | (f, c) <- files]
+    forM_ files $ \(f, expectedContent) -> do
+        content <- TI.readFile (tmpDir </> f)
+        content `shouldBe` expectedContent
+    listDirectory tmpDir
+
+spec :: Spec
+spec =
+    describe "writeFiles" $ do
+        it "writes root files" $
+            withSystemTempDirectory "writeFiles-rootFiles" $ \tmpDir -> do
+                let files = [ ("a.txt", "content A")
+                            , ("b.txt", "content B")
+                            ]
+                fileList <- expectWriteFiles tmpDir files
+                fileList `shouldBe` [f | (f, _) <- files]
+        it "makes directories if necessary" $
+            withSystemTempDirectory "writeFiles-directories" $ \tmpDir -> do
+                let files = [ ("a.txt", "content A")
+                            , ("b.txt", "content B")
+                            , ("d/a.txt", "content d/a")
+                            , ("d/b/c.txt", "content d/b/c")
+                            , ("d2/a.txt", "content d2/a")
+                            ]
+                fileList <- expectWriteFiles tmpDir files
+                fileList `shouldBe` ["a.txt", "b.txt", "d", "d2"]
+                dFileList <- listDirectory $ tmpDir </> "d"
+                dFileList `shouldBe` ["a.txt", "b"]
+                dBFileList <- listDirectory $ tmpDir </> "d" </> "b"
+                dBFileList `shouldBe` ["c.txt"]
+                d2FileList <- listDirectory $ tmpDir </> "d2"
+                d2FileList `shouldBe` ["a.txt"]


### PR DESCRIPTION
As #28 pointed `nirum` CLI had failed to generate Python files since it had not make necessary leaf directories.  This patch fixes the bug #28, and adds regression tests for the bug.
