### PR TITLE
Unify docs into annotations

### DIFF
--- a/nirum.cabal
+++ b/nirum.cabal
@@ -77,6 +77,7 @@ test-suite spec
                ,       Nirum.Constructs.ModuleSpec
                ,       Nirum.Constructs.ModulePathSpec
                ,       Nirum.Constructs.NameSpec
+               ,       Nirum.Constructs.ServiceSpec
                ,       Nirum.Constructs.TypeDeclarationSpec
                ,       Nirum.Constructs.TypeExpressionSpec
                ,       Nirum.PackageSpec

--- a/nirum.cabal
+++ b/nirum.cabal
@@ -21,6 +21,7 @@ library
   exposed-modules:     Nirum.Cli
                  ,     Nirum.Constructs
                  ,     Nirum.Constructs.Annotation
+                 ,     Nirum.Constructs.Annotation.Internal
                  ,     Nirum.Constructs.Declaration
                  ,     Nirum.Constructs.DeclarationSet
                  ,     Nirum.Constructs.Identifier

--- a/src/Nirum/Constructs/Annotation.hs
+++ b/src/Nirum/Constructs/Annotation.hs
@@ -1,45 +1,34 @@
-{-# LANGUAGE OverloadedStrings, QuasiQuotes #-}
+{-# LANGUAGE OverloadedStrings #-}
 module Nirum.Constructs.Annotation ( Annotation(Annotation)
-                                   , AnnotationSet(AnnotationSet)
+                                   , AnnotationSet
                                    , Metadata
                                    , NameDuplication(AnnotationNameDuplication)
                                    , annotations
+                                   , docs
                                    , empty
                                    , fromList
+                                   , insertDocs
+                                   , lookup
+                                   , lookupDocs
+                                   , singleton
                                    , toCode
                                    , toList
+                                   , union
                                    ) where
+
+import Prelude hiding (lookup)
 
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
-import qualified Data.Text as T
-import Text.InterpolatedString.Perl6 (qq)
 
 import Nirum.Constructs (Construct (toCode))
+import Nirum.Constructs.Annotation.Internal
+import Nirum.Constructs.Declaration (Docs (Docs), annotationDocsName, toText)
 import Nirum.Constructs.Identifier (Identifier)
 
 
-type Metadata = T.Text
-
--- | Annotation for 'Declaration'.
-data Annotation = Annotation { name :: Identifier
-                             , metadata :: Maybe Metadata
-                             } deriving (Eq, Ord, Show)
-
-instance Construct Annotation where
-    toCode Annotation {name = n,  metadata = Just m} =
-        let m' = T.replace "\"" "\\\"" m in [qq|@{toCode n}("$m'")|]
-    toCode Annotation {name = n,  metadata = Nothing} = [qq|@{toCode n}|]
-
-data AnnotationSet
-  -- | The set of 'Annotation' values.
-  -- Every annotation name has to be unique in the set.
-  = AnnotationSet { annotations :: M.Map Identifier Annotation }
-  deriving (Eq, Ord, Show)
-
-instance Construct AnnotationSet where
-    toCode AnnotationSet {annotations = annotations'} =
-        T.concat [s | e <- M.elems annotations', s <- [toCode e, "\n"]]
+docs :: Docs -> Annotation
+docs (Docs d) = Annotation { name = annotationDocsName, metadata = Just d }
 
 data NameDuplication = AnnotationNameDuplication Identifier
                      deriving (Eq, Ord, Show)
@@ -47,14 +36,18 @@ data NameDuplication = AnnotationNameDuplication Identifier
 empty :: AnnotationSet
 empty = AnnotationSet { annotations = M.empty }
 
+singleton :: Annotation -> AnnotationSet
+singleton Annotation { name = name', metadata = metadata' } =
+    AnnotationSet { annotations = M.singleton name' metadata' }
+
 fromList :: [Annotation] -> Either NameDuplication AnnotationSet
 fromList annotations' =
     case findDup names S.empty of
         Just duplication -> Left (AnnotationNameDuplication duplication)
-        _ -> Right AnnotationSet { annotations = M.fromList [ (name a, a)
-                                                            | a <- annotations'
-                                                            ]
-                                 }
+        _ -> Right $ AnnotationSet ( M.fromList [ (name a, metadata a)
+                                                | a <- annotations'
+                                                ]
+                                   )
   where
     names :: [Identifier]
     names = [name a | a <- annotations']
@@ -67,4 +60,28 @@ fromList annotations' =
             _ -> Nothing
 
 toList :: AnnotationSet -> [Annotation]
-toList AnnotationSet { annotations = annotations' } = M.elems annotations'
+toList AnnotationSet { annotations = annotations' } =
+    map fromTuple $ M.assocs annotations'
+
+union :: AnnotationSet -> AnnotationSet -> AnnotationSet
+union (AnnotationSet a) (AnnotationSet b) = AnnotationSet $ M.union a b
+
+lookup :: Identifier -> AnnotationSet -> Maybe Annotation
+lookup id' (AnnotationSet anno) = do
+    metadata' <- M.lookup id' anno
+    return Annotation { name = id', metadata = metadata' }
+
+lookupDocs :: AnnotationSet -> Maybe Docs
+lookupDocs annotationSet = do
+    Annotation _ m <- lookup annotationDocsName annotationSet
+    data' <- m
+    return $ Docs data'
+
+insertDocs :: (Monad m) => Docs -> AnnotationSet -> m AnnotationSet
+insertDocs docs' (AnnotationSet anno) =
+    case insertLookup annotationDocsName (Just $ toText docs') anno of
+        (Just _ , _    ) -> fail "<duplicated>"
+        (Nothing, anno') -> return $ AnnotationSet anno'
+  where
+    insertLookup :: Ord k => k -> a -> M.Map k a -> (Maybe a, M.Map k a)
+    insertLookup = M.insertLookupWithKey (\_ a _ -> a)

--- a/src/Nirum/Constructs/Annotation/Internal.hs
+++ b/src/Nirum/Constructs/Annotation/Internal.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE OverloadedStrings, QuasiQuotes #-}
+module Nirum.Constructs.Annotation.Internal ( Annotation(..)
+                                            , AnnotationSet(..)
+                                            , Metadata
+                                            , fromTuple
+                                            ) where
+
+import qualified Data.Map.Strict as M
+import qualified Data.Text as T
+import Text.InterpolatedString.Perl6 (qq)
+
+import Nirum.Constructs (Construct (toCode))
+import Nirum.Constructs.Declaration (annotationDocsName)
+import Nirum.Constructs.Identifier (Identifier)
+
+
+type Metadata = T.Text
+
+-- | Annotation for 'Declaration'.
+data Annotation = Annotation { name :: Identifier
+                             , metadata :: Maybe Metadata
+                             } deriving (Eq, Ord, Show)
+
+instance Construct Annotation where
+    toCode Annotation {name = n,  metadata = Just m} =
+        let m' = T.replace "\"" "\\\"" m in [qq|@{toCode n}("$m'")|]
+    toCode Annotation {name = n,  metadata = Nothing} = [qq|@{toCode n}|]
+
+fromTuple :: (Identifier, Maybe Metadata) -> Annotation
+fromTuple (name', meta') = Annotation { name = name', metadata = meta' }
+
+data AnnotationSet
+  -- | The set of 'Annotation' values.
+  -- Every annotation name has to be unique in the set.
+  = AnnotationSet { annotations :: M.Map Identifier (Maybe Metadata) }
+  deriving (Eq, Ord, Show)
+
+instance Construct AnnotationSet where
+    toCode AnnotationSet {annotations = annotations'} =
+        T.concat [s | e <- M.assocs annotations'
+                    , fst e /= annotationDocsName
+                    , s <- [toCode $ fromTuple e, "\n"]]

--- a/src/Nirum/Constructs/Declaration.hs
+++ b/src/Nirum/Constructs/Declaration.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Nirum.Constructs.Declaration ( Declaration
                                     , Docs(Docs)
+                                    , annotationDocsName
                                     , docs
                                     , name
                                     , toCode
@@ -13,7 +14,11 @@ import Data.String (IsString(fromString))
 import qualified Data.Text as T
 
 import Nirum.Constructs (Construct(toCode))
+import Nirum.Constructs.Identifier (Identifier)
 import Nirum.Constructs.Name (Name)
+
+annotationDocsName :: Identifier
+annotationDocsName = "doc"
 
 -- 'Construct' which has its own unique 'name' and can has its 'docs'.
 class Construct a => Declaration a where

--- a/src/Nirum/Constructs/Declaration.hs
+++ b/src/Nirum/Constructs/Declaration.hs
@@ -18,7 +18,7 @@ import Nirum.Constructs.Identifier (Identifier)
 import Nirum.Constructs.Name (Name)
 
 annotationDocsName :: Identifier
-annotationDocsName = "doc"
+annotationDocsName = "docs"
 
 -- 'Construct' which has its own unique 'name' and can has its 'docs'.
 class Construct a => Declaration a where

--- a/src/Nirum/Constructs/Module.hs
+++ b/src/Nirum/Constructs/Module.hs
@@ -67,25 +67,29 @@ coreModule = Module coreTypes $ Just coreDocs
 coreTypes :: DS.DeclarationSet TypeDeclaration
 coreTypes =
     -- number types
-    [ TypeDeclaration "bigint" (PrimitiveType Bigint String) Nothing empty
-    , TypeDeclaration "decimal" (PrimitiveType Decimal String) Nothing empty
-    , TypeDeclaration "int32" (PrimitiveType Int32 Number) Nothing empty
-    , TypeDeclaration "int64" (PrimitiveType Int64 Number) Nothing empty
-    , TypeDeclaration "float32" (PrimitiveType Float32 Number) Nothing empty
-    , TypeDeclaration "float64" (PrimitiveType Float64 Number) Nothing empty
+    [ decl' "bigint" Bigint String
+    , decl' "decimal" Decimal String
+    , decl' "int32" Int32 Number
+    , decl' "int64" Int64 Number
+    , decl' "float32" Float32 Number
+    , decl' "float64" Float64 Number
     -- string types
-    , TypeDeclaration "text" (PrimitiveType Text String) Nothing empty
-    , TypeDeclaration "binary" (PrimitiveType Binary String) Nothing empty
+    , decl' "text" Text String
+    , decl' "binary" Binary String
     -- time types
-    , TypeDeclaration
-          "date" (PrimitiveType Date String) Nothing empty
-    , TypeDeclaration
-          "datetime" (PrimitiveType Datetime String) Nothing empty
+    , decl' "date" Date String
+    , decl' "datetime" Datetime String
     -- et cetera
-    , TypeDeclaration "bool" (PrimitiveType Bool Boolean) Nothing empty
-    , TypeDeclaration "uuid" (PrimitiveType Uuid String) Nothing empty
-    , TypeDeclaration "uri" (PrimitiveType Uri String) Nothing empty
+    , decl' "bool" Bool Boolean
+    , decl' "uuid" Uuid String
+    , decl' "uri" Uri String
     ]
+  where
+    decl' name prim json =
+        TypeDeclaration { typename = name
+                        , type' = PrimitiveType prim json
+                        , typeAnnotations = empty
+                        }
 
 coreDocs :: Docs
 coreDocs = [q|

--- a/src/Nirum/Constructs/Service.hs
+++ b/src/Nirum/Constructs/Service.hs
@@ -1,19 +1,19 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Nirum.Constructs.Service ( Method ( Method
                                          , methodAnnotations
-                                         , methodDocs
                                          , methodName
                                          , parameters
                                          , returnType
                                          )
                                 , Parameter(Parameter)
                                 , Service(Service, methods)
+                                , methodDocs
                                 ) where
 
 import qualified Data.Text as T
 
 import Nirum.Constructs (Construct(toCode))
-import Nirum.Constructs.Annotation (AnnotationSet)
+import Nirum.Constructs.Annotation (AnnotationSet, lookupDocs)
 import Nirum.Constructs.Declaration ( Declaration(name, docs)
                                     , Docs
                                     , toCodeWithPrefix
@@ -44,14 +44,15 @@ data Method = Method { methodName :: Name
                      , parameters :: DeclarationSet Parameter
                      , returnType :: TypeExpression
                      , errorType  :: Maybe TypeExpression
-                     , methodDocs :: Maybe Docs
                      , methodAnnotations :: AnnotationSet
                      } deriving (Eq, Ord, Show)
+
+methodDocs :: Method -> Maybe Docs
+methodDocs = lookupDocs . methodAnnotations
 
 instance Construct Method where
     toCode method@Method { parameters = params
                          , errorType = error'
-                         , methodDocs = docs'
                          , methodAnnotations = annotationSet'
                          } =
         T.concat $ [ toCode annotationSet'
@@ -77,6 +78,8 @@ instance Construct Method where
       where
         params' :: [Parameter]
         params' = toList params
+        docs' :: Maybe Docs
+        docs' = lookupDocs annotationSet'
         indentedCode :: Construct a => a -> T.Text
         indentedCode c = T.concat [ "  "
                                   , T.intercalate "\n  " $ T.lines (toCode c)

--- a/src/Nirum/Parser.hs
+++ b/src/Nirum/Parser.hs
@@ -251,7 +251,10 @@ aliasTypeDeclaration = do
     spaces
     char ';'
     docs' <- optional $ try $ spaces >> (docs <?> "type alias docs")
-    return $ TypeDeclaration name' (Alias canonicalType) docs' annotationSet'
+    annotationSet'' <- case docs' of
+        Just d  -> A.insertDocs d annotationSet'
+        Nothing -> return annotationSet'
+    return $ TypeDeclaration name' (Alias canonicalType) annotationSet''
 
 
 boxedTypeDeclaration :: Parser TypeDeclaration
@@ -270,7 +273,10 @@ boxedTypeDeclaration = do
     spaces
     char ';'
     docs' <- optional $ try $ spaces >> (docs <?> "boxed type docs")
-    return $ TypeDeclaration name' (BoxedType innerType) docs' annotationSet'
+    annotationSet'' <- case docs' of
+        Just d  -> A.insertDocs d annotationSet'
+        Nothing -> return annotationSet'
+    return $ TypeDeclaration name' (BoxedType innerType) annotationSet''
 
 enumMember :: Parser EnumMember
 enumMember = do
@@ -315,6 +321,9 @@ enumTypeDeclaration = do
             d <- docs <?> "enum type docs"
             spaces
             return d
+    annotationSet'' <- case docs' of
+        Just d  -> A.insertDocs d annotationSet'
+        Nothing -> return annotationSet'
     members <- (enumMember `sepBy1` (spaces >> char '|' >> spaces))
                    <?> "enum members"
     case fromList members of
@@ -328,7 +337,7 @@ enumTypeDeclaration = do
             spaces
             char ';'
             return $ TypeDeclaration typename (EnumType memberSet)
-                                     docs' annotationSet'
+                                     annotationSet''
 
 fieldsOrParameters :: forall a. (String, String)
                    -> (Name -> TypeExpression -> Maybe Docs -> a)
@@ -384,7 +393,10 @@ recordTypeDeclaration = do
     char ')'
     spaces
     char ';'
-    return $ TypeDeclaration typename (RecordType fields') docs' annotationSet'
+    annotationSet'' <- case docs' of
+        Just d  -> A.insertDocs d annotationSet'
+        Nothing -> return annotationSet'
+    return $ TypeDeclaration typename (RecordType fields') annotationSet''
 
 tag :: Parser Tag
 tag = do
@@ -420,8 +432,11 @@ unionTypeDeclaration = do
              <?> "union tags"
     spaces
     char ';'
+    annotationSet'' <- case docs' of
+        Just d  -> A.insertDocs d annotationSet'
+        Nothing -> return annotationSet'
     handleNameDuplication "tag" tags' $ \tagSet ->
-        return $ TypeDeclaration typename (UnionType tagSet) docs' annotationSet'
+        return $ TypeDeclaration typename (UnionType tagSet) annotationSet''
 
 typeDeclaration :: Parser TypeDeclaration
 typeDeclaration =
@@ -463,7 +478,10 @@ method = do
         e <- typeExpression <?> "method error type"
         spaces
         return e
-    return $ Method methodName params returnType errorType docs' annotationSet'
+    annotationSet'' <- case docs' of
+        Just d  -> A.insertDocs d annotationSet'
+        Nothing -> return annotationSet'
+    return $ Method methodName params returnType errorType annotationSet''
 
 methods :: Parser [Method]
 methods = method `sepEndBy` try (spaces >> char ',' >> spaces)
@@ -491,8 +509,10 @@ serviceDeclaration = do
     char ')'
     spaces
     char ';'
-    return $ ServiceDeclaration serviceName (Service methods')
-                                docs' annotationSet'
+    annotationSet'' <- case docs' of
+        Just d  -> A.insertDocs d annotationSet'
+        Nothing -> return annotationSet'
+    return $ ServiceDeclaration serviceName (Service methods') annotationSet''
 
 modulePath :: Parser ModulePath
 modulePath = do

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -59,10 +59,7 @@ import Nirum.Constructs.TypeDeclaration ( EnumMember(EnumMember)
                                               , RecordType
                                               , UnionType
                                               )
-                                        , TypeDeclaration( Import
-                                                         , ServiceDeclaration
-                                                         , TypeDeclaration
-                                                         )
+                                        , TypeDeclaration(..)
                                         )
 import Nirum.Constructs.TypeExpression ( TypeExpression( ListModifier
                                                        , MapModifier
@@ -193,10 +190,10 @@ compileUnionTag :: Source
                 -> Name
                 -> DS.DeclarationSet Field
                 -> CodeGen Code
-compileUnionTag source parentname typename fields = do
+compileUnionTag source parentname typename' fields = do
     typeExprCodes <- mapM (compileTypeExpression source)
         [typeExpr | (Field _ typeExpr _) <- toList fields]
-    let className = toClassName' typename
+    let className = toClassName' typename'
         tagNames = map toAttributeName' [ name
                                         | (Field name _ _) <- toList fields
                                         ]
@@ -224,7 +221,7 @@ class $className($parentClass):
     __slots__ = (
         $slots,
     )
-    __nirum_tag__ = $parentClass.Tag.{toAttributeName' typename}
+    __nirum_tag__ = $parentClass.Tag.{toAttributeName' typename'}
     __nirum_tag_types__ = \{
         $slotTypes
     \}
@@ -294,16 +291,18 @@ compileTypeExpression source modifier = do
         MapModifier _ _ -> undefined  -- never happen!
 
 compileTypeDeclaration :: Source -> TypeDeclaration -> CodeGen Code
-compileTypeDeclaration _ (TypeDeclaration _ (PrimitiveType _ _) _ _) =
+compileTypeDeclaration _ TypeDeclaration { type' = PrimitiveType { } } =
     return ""  -- never used
-compileTypeDeclaration src (TypeDeclaration typename (Alias ctype) _ _) = do
+compileTypeDeclaration src TypeDeclaration { typename = typename'
+                                           , type' = Alias ctype } = do
     ctypeExpr <- compileTypeExpression src ctype
     return [qq|
 # TODO: docstring
-{toClassName' typename} = $ctypeExpr
+{toClassName' typename'} = $ctypeExpr
     |]
-compileTypeDeclaration src (TypeDeclaration typename (BoxedType itype) _ _) = do
-    let className = toClassName' typename
+compileTypeDeclaration src TypeDeclaration { typename = typename'
+                                           , type' = BoxedType itype } = do
+    let className = toClassName' typename'
     itypeExpr <- compileTypeExpression src itype
     withStandardImport "typing" $
         withThirdPartyImports [ ("nirum.validate", ["validate_boxed_type"])
@@ -341,8 +340,9 @@ class $className:
             type(self), self.value
         )
             |]
-compileTypeDeclaration _ (TypeDeclaration typename (EnumType members) _ _) = do
-    let className = toClassName' typename
+compileTypeDeclaration _ TypeDeclaration { typename = typename'
+                                         , type' = EnumType members } = do
+    let className = toClassName' typename'
         memberNames = T.intercalate
             "\n    "
             [ [qq|{toAttributeName' memberName} = '{toSnakeCaseText bn}'|]
@@ -361,10 +361,11 @@ class $className(enum.Enum):
     def __nirum_deserialize__(cls: type, value: str) -> '{className}':
         return cls(value.replace('-', '_'))  # FIXME: validate input
     |]
-compileTypeDeclaration src (TypeDeclaration typename (RecordType fields) _ _) = do
+compileTypeDeclaration src TypeDeclaration { typename = typename'
+                                           , type' = RecordType fields } = do
     typeExprCodes <- mapM (compileTypeExpression src)
         [typeExpr | (Field _ typeExpr _) <- toList fields]
-    let className = toClassName' typename
+    let className = toClassName' typename'
         fieldNames = map toAttributeName' [ name
                                           | (Field name _ _) <- toList fields
                                           ]
@@ -396,7 +397,7 @@ class $className:
     __slots__ = (
         $slots,
     )
-    __nirum_record_behind_name__ = '{toSnakeCaseText $ N.behindName typename}'
+    __nirum_record_behind_name__ = '{toSnakeCaseText $ N.behindName typename'}'
     __nirum_field_types__ = \{
         $slotTypes
     \}
@@ -428,9 +429,10 @@ class $className:
     def __nirum_deserialize__(cls: type, value) -> '{className}':
         return deserialize_record_type(cls, value)
                         |]
-compileTypeDeclaration src (TypeDeclaration typename (UnionType tags) _ _) = do
-    fieldCodes <- mapM (uncurry (compileUnionTag src typename)) tagNameNFields
-    let className = toClassName' typename
+compileTypeDeclaration src TypeDeclaration { typename = typename'
+                                           , type' = UnionType tags } = do
+    fieldCodes <- mapM (uncurry (compileUnionTag src typename')) tagNameNFields
+    let className = toClassName' typename'
         fieldCodes' = T.intercalate "\n\n" fieldCodes
         enumMembers = toIndentedCodes
             (\(t, b) -> [qq|$t = '{b}'|]) enumMembers' "\n        "
@@ -445,7 +447,7 @@ compileTypeDeclaration src (TypeDeclaration typename (UnionType tags) _ _) = do
                 return [qq|
 class $className:
 
-    __nirum_union_behind_name__ = '{toSnakeCaseText $ N.behindName typename}'
+    __nirum_union_behind_name__ = '{toSnakeCaseText $ N.behindName typename'}'
     __nirum_field_names__ = name_dict_type([
         $nameMaps
     ])
@@ -488,7 +490,8 @@ $fieldCodes'
         toNamePair
         [name | (name, _) <- tagNameNFields]
         ",\n        "
-compileTypeDeclaration src (ServiceDeclaration name (Service methods) _ _) = do
+compileTypeDeclaration src ServiceDeclaration { serviceName = name
+                                              , service = Service methods } = do
     let methods' = toList methods
     methodMetadata <- mapM compileMethodMetadata methods'
     let methodMetadata' = commaNl methodMetadata
@@ -515,7 +518,7 @@ class $className(service_type):
     commaNl :: [T.Text] -> T.Text
     commaNl = T.intercalate ",\n"
     compileMethod :: Method -> CodeGen Code
-    compileMethod (Method mName params rtype _etype _docs _anno) = do
+    compileMethod (Method mName params rtype _etype _anno) = do
         let mName' = toAttributeName' mName
         params' <- mapM compileParameter $ toList params
         rtypeExpr <- compileTypeExpression src rtype
@@ -528,7 +531,7 @@ class $className(service_type):
         pTypeExpr <- compileTypeExpression src pType
         return [qq|{toAttributeName' pName}: $pTypeExpr|]
     compileMethodMetadata :: Method -> CodeGen Code
-    compileMethodMetadata (Method mName params rtype _etype _docs _anno) = do
+    compileMethodMetadata (Method mName params rtype _etype _anno) = do
         let params' = toList params :: [Parameter]
         rtypeExpr <- compileTypeExpression src rtype
         paramMetadata <- mapM compileParameterMetadata params'
@@ -552,7 +555,7 @@ class $className(service_type):
     paramNameMap :: [Parameter] -> T.Text
     paramNameMap params = toIndentedCodes
         toNamePair [pName | Parameter pName _ _ <- params] ",\n        "
-compileTypeDeclaration _ (Import _ _) =
+compileTypeDeclaration _ Import { } =
     return ""  -- Nothing to compile
 
 compileModuleBody :: Source -> CodeGen Code

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -53,7 +53,11 @@ import Nirum.Constructs.Identifier ( Identifier
 import Nirum.Constructs.ModulePath (ModulePath, ancestors)
 import Nirum.Constructs.Name (Name(Name))
 import qualified Nirum.Constructs.Name as N
-import Nirum.Constructs.Service ( Method(Method, methodName)
+import Nirum.Constructs.Service ( Method( Method
+                                        , methodName
+                                        , parameters
+                                        , returnType
+                                        )
                                 , Parameter(Parameter)
                                 , Service(Service)
                                 )
@@ -555,7 +559,10 @@ class {className}_Client(client_type, $className):
         pTypeExpr <- compileTypeExpression src pType
         return [qq|{toAttributeName' pName}: $pTypeExpr|]
     compileMethodMetadata :: Method -> CodeGen Code
-    compileMethodMetadata (Method mName params rtype _etype _anno) = do
+    compileMethodMetadata Method { methodName = mName
+                                 , parameters = params
+                                 , returnType = rtype
+                                 } = do
         let params' = toList params :: [Parameter]
         rtypeExpr <- compileTypeExpression src rtype
         paramMetadata <- mapM compileParameterMetadata params'
@@ -584,7 +591,10 @@ class {className}_Client(client_type, $className):
         let pName' = toAttributeName' pName
         return [qq|meta['_names']['{pName'}']: serialize_meta({pName'})|]
     compileClientMethod :: Method -> CodeGen Code
-    compileClientMethod (Method mName params rtype _ _ _) = do
+    compileClientMethod Method { methodName = mName
+                               , parameters = params
+                               , returnType = rtype
+                               } = do
         let clientMethodName' = toAttributeName' mName
         params' <- mapM compileParameter $ toList params
         rtypeExpr <- compileTypeExpression src rtype

--- a/test/Nirum/Constructs/AnnotationSpec.hs
+++ b/test/Nirum/Constructs/AnnotationSpec.hs
@@ -1,37 +1,52 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedLists, OverloadedStrings #-}
 module Nirum.Constructs.AnnotationSpec where
 
 import Test.Hspec.Meta
 import qualified Data.Map.Strict as M
 
-import Nirum.Constructs.Annotation
+import Nirum.Constructs.Annotation as A
     ( Annotation (Annotation)
-    , AnnotationSet (AnnotationSet)
     , NameDuplication (AnnotationNameDuplication)
+    , docs
     , empty
     , fromList
+    , insertDocs
+    , lookup
+    , lookupDocs
+    , singleton
     , toCode
     , toList
+    , union
     )
+import Nirum.Constructs.Annotation.Internal ( AnnotationSet (AnnotationSet) )
 
 spec :: Spec
 spec = do
     let annotation = Annotation "foo" Nothing
         loremAnno = Annotation "lorem" (Just "ipsum")
-        withEscapeChar = Annotation "quote" (Just "\"")
-    describe "Annotation" $
+        escapeCharAnno = Annotation "quote" (Just "\"")
+        longNameAnno = Annotation "long-cat-is-long" (Just "nyancat")
+        docsAnno = docs "Description"
+    describe "Annotation" $ do
         describe "toCode Annotation" $
             it "prints annotation properly" $ do
                 toCode annotation `shouldBe` "@foo"
                 toCode loremAnno `shouldBe` "@lorem(\"ipsum\")"
-                toCode withEscapeChar `shouldBe` "@quote(\"\\\"\")"
+                toCode escapeCharAnno `shouldBe` "@quote(\"\\\"\")"
+        specify "docs" $
+            docsAnno `shouldBe` Annotation "doc" (Just "Description\n")
     describe "AnnotationSet" $ do
         it "empty" $ empty `shouldBe` AnnotationSet M.empty
+        it "singleton" $ do
+            singleton (Annotation "foo" Nothing) `shouldBe`
+                AnnotationSet [("foo", Nothing)]
+            singleton (Annotation "bar" (Just "baz")) `shouldBe`
+                AnnotationSet [("bar", Just "baz")]
         describe "fromList" $ do
             it "success" $ do
                 fromList [] `shouldBe` Right (AnnotationSet M.empty)
                 fromList [annotation] `shouldBe` Right
-                    (AnnotationSet $ M.fromList [("foo", annotation)])
+                    (AnnotationSet $ M.fromList [("foo", Nothing)])
             it "name duplication" $ do
                 let duplicationAnnotations = fromList [ annotation
                                                       , loremAnno
@@ -39,8 +54,42 @@ spec = do
                                                       ]
                 duplicationAnnotations `shouldBe`
                     Left (AnnotationNameDuplication "foo")
-        let annotationSet = case fromList [annotation, loremAnno] of
-                                Right set -> set
-                                Left _ -> empty
+        specify "union" $ do
+            let Right a = fromList [annotation, loremAnno]
+            let Right b = fromList [docsAnno, escapeCharAnno]
+            let c = AnnotationSet [("foo", Just "bar")]
+            A.union a b `shouldBe` AnnotationSet [ ("foo", Nothing)
+                                                 , ("lorem", Just "ipsum")
+                                                 , ("quote", Just "\"")
+                                                 , ("doc", Just "Description\n")
+                                                 ]
+            A.union a c `shouldBe` a
+        let Right annotationSet = fromList [ annotation
+                                           , loremAnno
+                                           , escapeCharAnno
+                                           , longNameAnno
+                                           , docsAnno
+                                           ]
         it "toList" $
             fromList (toList annotationSet) `shouldBe` Right annotationSet
+        describe "lookup" $ do
+            it "should find proper annotation" $ do
+                A.lookup "foo" annotationSet `shouldBe` Just annotation
+                A.lookup "FOO" annotationSet `shouldBe` Just annotation
+                A.lookup "lorem" annotationSet `shouldBe` Just loremAnno
+                A.lookup "quote" annotationSet `shouldBe` Just escapeCharAnno
+                A.lookup "long-cat-is-long" annotationSet `shouldBe` Just longNameAnno
+                A.lookup "long_cat_is_long" annotationSet `shouldBe` Just longNameAnno
+                A.lookup "doc" annotationSet `shouldBe` Just docsAnno
+            it "should be Nothing if lookup fails" $ do
+                A.lookup "bar" annotationSet `shouldBe` Nothing
+                A.lookup "longCatIsLong" annotationSet `shouldBe` Nothing
+        specify "lookupDocs" $ do
+            A.lookupDocs annotationSet `shouldBe` Just "Description"
+            A.lookupDocs empty `shouldBe` Nothing
+        describe "insertDocs" $ do
+            it "should insert the doc comment as an annotation" $
+                A.insertDocs "yay" empty `shouldReturn`
+                    AnnotationSet [("doc", Just "yay\n")]
+            it "should fail on the annotation that already have a doc" $
+                A.insertDocs "yay" annotationSet `shouldThrow` anyException

--- a/test/Nirum/Constructs/AnnotationSpec.hs
+++ b/test/Nirum/Constructs/AnnotationSpec.hs
@@ -34,7 +34,7 @@ spec = do
                 toCode loremAnno `shouldBe` "@lorem(\"ipsum\")"
                 toCode escapeCharAnno `shouldBe` "@quote(\"\\\"\")"
         specify "docs" $
-            docsAnno `shouldBe` Annotation "doc" (Just "Description\n")
+            docsAnno `shouldBe` Annotation "docs" (Just "Description\n")
     describe "AnnotationSet" $ do
         it "empty" $ empty `shouldBe` AnnotationSet M.empty
         it "singleton" $ do
@@ -61,7 +61,7 @@ spec = do
             A.union a b `shouldBe` AnnotationSet [ ("foo", Nothing)
                                                  , ("lorem", Just "ipsum")
                                                  , ("quote", Just "\"")
-                                                 , ("doc", Just "Description\n")
+                                                 , ("docs", Just "Description\n")
                                                  ]
             A.union a c `shouldBe` a
         let Right annotationSet = fromList [ annotation
@@ -80,7 +80,7 @@ spec = do
                 A.lookup "quote" annotationSet `shouldBe` Just escapeCharAnno
                 A.lookup "long-cat-is-long" annotationSet `shouldBe` Just longNameAnno
                 A.lookup "long_cat_is_long" annotationSet `shouldBe` Just longNameAnno
-                A.lookup "doc" annotationSet `shouldBe` Just docsAnno
+                A.lookup "docs" annotationSet `shouldBe` Just docsAnno
             it "should be Nothing if lookup fails" $ do
                 A.lookup "bar" annotationSet `shouldBe` Nothing
                 A.lookup "longCatIsLong" annotationSet `shouldBe` Nothing
@@ -90,6 +90,6 @@ spec = do
         describe "insertDocs" $ do
             it "should insert the doc comment as an annotation" $
                 A.insertDocs "yay" empty `shouldReturn`
-                    AnnotationSet [("doc", Just "yay\n")]
+                    AnnotationSet [("docs", Just "yay\n")]
             it "should fail on the annotation that already have a doc" $
                 A.insertDocs "yay" annotationSet `shouldThrow` anyException

--- a/test/Nirum/Constructs/ModuleSpec.hs
+++ b/test/Nirum/Constructs/ModuleSpec.hs
@@ -5,7 +5,7 @@ import Test.Hspec.Meta
 import Text.InterpolatedString.Perl6 (q)
 
 import Nirum.Constructs (Construct(toCode))
-import Nirum.Constructs.Annotation (empty)
+import Nirum.Constructs.Annotation as A (docs, empty, singleton)
 import Nirum.Constructs.DeclarationSet (DeclarationSet)
 import Nirum.Constructs.Module (Module(..), imports)
 import Nirum.Constructs.TypeDeclaration ( Type(..)
@@ -17,10 +17,10 @@ import Nirum.Constructs.TypeDeclaration ( Type(..)
 spec :: Spec
 spec =
     describe "Module" $ do
-        let pathT = TypeDeclaration "path" (Alias "text")
-                                    (Just "path string") empty
+        let docsAnno = A.docs "path string"
+            pathT = TypeDeclaration "path" (Alias "text") (singleton docsAnno)
             offsetT =
-                TypeDeclaration "offset" (BoxedType "float64") Nothing empty
+                TypeDeclaration "offset" (BoxedType "float64") empty
             decls = [ Import ["foo", "bar"] "baz"
                     , Import ["foo", "bar"] "qux"
                     , Import ["zzz"] "qqq"

--- a/test/Nirum/Constructs/ServiceSpec.hs
+++ b/test/Nirum/Constructs/ServiceSpec.hs
@@ -3,7 +3,13 @@ module Nirum.Constructs.ServiceSpec where
 
 import Test.Hspec.Meta
 
-import Nirum.Constructs.Annotation (Annotation (Annotation), empty, fromList)
+import Nirum.Constructs.Annotation (Annotation (Annotation)
+                                   , docs
+                                   , empty
+                                   , fromList
+                                   , singleton
+                                   , union
+                                   )
 import Nirum.Constructs.Declaration (toCode)
 import Nirum.Constructs.Service (Method(Method), Parameter(Parameter))
 import Nirum.Constructs.TypeExpression ( TypeExpression ( ListModifier
@@ -15,6 +21,7 @@ import Nirum.Constructs.TypeExpression ( TypeExpression ( ListModifier
 spec :: Spec
 spec = do
     let Right methodAnno = fromList [Annotation "http-get" (Just "/ping/")]
+    let docsAnno = singleton $ docs "docs..."
     describe "Parameter" $
         specify "toCode" $ do
             toCode (Parameter "dob" "date" Nothing) `shouldBe` "date dob,"
@@ -24,43 +31,35 @@ spec = do
         specify "toCode" $ do
             toCode (Method "ping" [] "bool"
                            Nothing
-                           Nothing
                            empty) `shouldBe`
                 "bool ping (),"
             toCode (Method "ping" [] "bool"
                            Nothing
-                           Nothing
                            methodAnno) `shouldBe`
                 "@http-get(\"/ping/\")\nbool ping (),"
             toCode (Method "ping" [] "bool"
                            Nothing
-                           (Just "docs...")
-                           empty) `shouldBe`
+                           docsAnno) `shouldBe`
                 "bool ping (\n  # docs...\n),"
             toCode (Method "ping" [] "bool"
                            (Just "ping-error")
-                           Nothing
                            empty) `shouldBe`
                 "bool ping () throws ping-error,"
             toCode (Method "ping" [] "bool"
                            (Just "ping-error")
-                           (Just "docs...")
-                           empty) `shouldBe`
+                           docsAnno) `shouldBe`
                 "bool ping (\n  # docs...\n) throws ping-error,"
             toCode (Method "ping" [] "bool"
-                           Nothing
                            Nothing
                            methodAnno) `shouldBe`
                 "@http-get(\"/ping/\")\nbool ping (),"
             toCode (Method "ping" [] "bool"
                            (Just "ping-error")
-                           Nothing
                            methodAnno) `shouldBe`
                 "@http-get(\"/ping/\")\nbool ping () throws ping-error,"
             toCode (Method "get-user"
                            [Parameter "user-id" "uuid" Nothing]
                            (OptionModifier "user")
-                           Nothing
                            Nothing
                            empty) `shouldBe`
                 "user? get-user (uuid user-id),"
@@ -68,22 +67,19 @@ spec = do
                            [Parameter "user-id" "uuid" Nothing]
                            (OptionModifier "user")
                            Nothing
-                           (Just "docs...")
-                           empty) `shouldBe`
+                           docsAnno) `shouldBe`
                 "user? get-user (\n  # docs...\n  uuid user-id,\n),"
             toCode (Method "get-user"
                            [Parameter "user-id" "uuid" Nothing]
                            (OptionModifier "user")
                            (Just "get-user-error")
-                           Nothing
                            empty) `shouldBe`
                 "user? get-user (uuid user-id) throws get-user-error,"
             toCode (Method "get-user"
                            [Parameter "user-id" "uuid" Nothing]
                            (OptionModifier "user")
                            (Just "get-user-error")
-                           (Just "docs...")
-                           empty) `shouldBe`
+                           docsAnno) `shouldBe`
                 "user? get-user (\n\
                 \  # docs...\n\
                 \  uuid user-id,\n\
@@ -92,15 +88,13 @@ spec = do
                            [Parameter "user-id" "uuid" $ Just "param docs..."]
                            (OptionModifier "user")
                            Nothing
-                           Nothing
                            empty) `shouldBe`
                 "user? get-user (\n  uuid user-id,\n  # param docs...\n),"
             toCode (Method "get-user"
                            [Parameter "user-id" "uuid" $ Just "param docs..."]
                            (OptionModifier "user")
                            Nothing
-                           (Just "docs...")
-                           empty) `shouldBe`
+                           docsAnno) `shouldBe`
                 "user? get-user (\n\
                 \  # docs...\n\
                 \  uuid user-id,\n\
@@ -110,7 +104,6 @@ spec = do
                            [Parameter "user-id" "uuid" $ Just "param docs..."]
                            (OptionModifier "user")
                            (Just "get-user-error")
-                           Nothing
                            empty) `shouldBe`
                 "user? get-user (\n\
                 \  uuid user-id,\n\
@@ -120,8 +113,7 @@ spec = do
                            [Parameter "user-id" "uuid" $ Just "param docs..."]
                            (OptionModifier "user")
                            (Just "get-user-error")
-                           (Just "docs...")
-                           empty) `shouldBe`
+                           docsAnno) `shouldBe`
                 "user? get-user (\n\
                 \  # docs...\n\
                 \  uuid user-id,\n\
@@ -132,7 +124,6 @@ spec = do
                            , Parameter "keyword" "text" Nothing
                            ]
                            (ListModifier "post")
-                           Nothing
                            Nothing
                            empty) `shouldBe`
                 "[post] search-posts (\n  uuid blog-id,\n  text keyword,\n),"
@@ -142,8 +133,7 @@ spec = do
                            ]
                            (ListModifier "post")
                            Nothing
-                           (Just "docs...")
-                           empty) `shouldBe`
+                           docsAnno) `shouldBe`
                 "[post] search-posts (\n\
                 \  # docs...\n\
                 \  uuid blog-id,\n\
@@ -155,7 +145,6 @@ spec = do
                            ]
                            (ListModifier "post")
                            (Just "search-posts-error")
-                           Nothing
                            empty) `shouldBe`
                 "[post] search-posts (\n\
                 \  uuid blog-id,\n\
@@ -167,8 +156,7 @@ spec = do
                            ]
                            (ListModifier "post")
                            (Just "search-posts-error")
-                           (Just "docs...")
-                           empty) `shouldBe`
+                           docsAnno) `shouldBe`
                 "[post] search-posts (\n\
                 \  # docs...\n\
                 \  uuid blog-id,\n\
@@ -179,7 +167,6 @@ spec = do
                            , Parameter "keyword" "text" $ Just "keyword..."
                            ]
                            (ListModifier "post")
-                           Nothing
                            Nothing
                            empty) `shouldBe`
                 "[post] search-posts (\n\
@@ -194,8 +181,7 @@ spec = do
                            ]
                            (ListModifier "post")
                            Nothing
-                           (Just "docs...")
-                           empty) `shouldBe`
+                           docsAnno) `shouldBe`
                 "[post] search-posts (\n\
                 \  # docs...\n\
                 \  uuid blog-id,\n\
@@ -209,7 +195,6 @@ spec = do
                            ]
                            (ListModifier "post")
                            (Just "search-posts-error")
-                           Nothing
                            empty) `shouldBe`
                 "[post] search-posts (\n\
                 \  uuid blog-id,\n\
@@ -223,8 +208,7 @@ spec = do
                            ]
                            (ListModifier "post")
                            (Just "search-posts-error")
-                           (Just "docs...")
-                           empty) `shouldBe`
+                           docsAnno) `shouldBe`
                 "[post] search-posts (\n\
                 \  # docs...\n\
                 \  uuid blog-id,\n\
@@ -238,8 +222,7 @@ spec = do
                            ]
                            (ListModifier "post")
                            (Just "search-posts-error")
-                           (Just "docs...")
-                           methodAnno) `shouldBe`
+                           (docsAnno `union` methodAnno)) `shouldBe`
                 "@http-get(\"/ping/\")\n\
                 \[post] search-posts (\n\
                 \  # docs...\n\

--- a/test/Nirum/Targets/PythonSpec.hs
+++ b/test/Nirum/Targets/PythonSpec.hs
@@ -242,22 +242,19 @@ makeDummySource m =
             [ (["foo"], m)
             , ( ["foo", "bar"]
               , Module [ Import ["qux"] "path"
-                       , TypeDeclaration "path-box" (BoxedType "path") Nothing
-                                         empty
-                       , TypeDeclaration "int-box" (BoxedType "bigint")
-                                         Nothing empty
+                       , TypeDeclaration "path-box" (BoxedType "path") empty
+                       , TypeDeclaration "int-box" (BoxedType "bigint") empty
                        , TypeDeclaration "point"
                                          (RecordType [ Field "x" "int64" Nothing
                                                      , Field "y" "int64" Nothing
                                                      ])
-                                         Nothing
                                          empty
                        ] Nothing
               )
             , ( ["qux"]
               , Module
-                  [ TypeDeclaration "path" (Alias "text") Nothing empty
-                  , TypeDeclaration "name" (BoxedType "text") Nothing empty
+                  [ TypeDeclaration "path" (Alias "text") empty
+                  , TypeDeclaration "name" (BoxedType "text") empty
                   ]
                   Nothing
               )
@@ -461,8 +458,7 @@ spec = parallel $ do
 
     describe "compilePackage" $ do
         specify "boxed type" $ do
-            let decl = TypeDeclaration "float-box" (BoxedType "float64")
-                                       Nothing empty
+            let decl = TypeDeclaration "float-box" (BoxedType "float64") empty
             tT decl "isinstance(FloatBox, type)"
             tT decl "FloatBox(3.14).value == 3.14"
             tT decl "FloatBox(3.14) == FloatBox(3.14)"
@@ -476,8 +472,7 @@ spec = parallel $ do
             tR' decl "TypeError" "FloatBox('a')"
             let decls = [ Import ["foo", "bar"] "path-box"
                         , TypeDeclaration "imported-type-box"
-                                          (BoxedType "path-box") Nothing
-                                          empty
+                                          (BoxedType "path-box") empty
                         ]
             tT' decls "isinstance(ImportedTypeBox, type)"
             tT' decls [q|ImportedTypeBox(PathBox('/path/string')).value.value ==
@@ -505,16 +500,14 @@ spec = parallel $ do
             tR'' decls "TypeError" "ImportedTypeBox(123)"
             let boxedAlias = [ Import ["qux"] "path"
                              , TypeDeclaration "way"
-                                               (BoxedType "path") Nothing
-                                               empty
+                                               (BoxedType "path") empty
                              ]
             tT' boxedAlias "Way('.').value == '.'"
             tT' boxedAlias "Way(Path('.')).value == '.'"
             tT' boxedAlias "Way.__nirum_deserialize__('.') == Way('.')"
             tT' boxedAlias "Way('.').__nirum_serialize__() == '.'"
             let aliasBoxed = [ Import ["qux"] "name"
-                             , TypeDeclaration "irum" (Alias "name") Nothing
-                                               empty
+                             , TypeDeclaration "irum" (Alias "name") empty
                              ]
             tT' aliasBoxed "Name('khj') == Irum('khj')"
             tT' aliasBoxed "Irum.__nirum_deserialize__('khj') == Irum('khj')"
@@ -525,8 +518,7 @@ spec = parallel $ do
             let members = [ "male"
                           , EnumMember (Name "female" "yeoseong") Nothing
                           ] :: DeclarationSet EnumMember
-                decl = TypeDeclaration "gender" (EnumType members) Nothing
-                                       empty
+                decl = TypeDeclaration "gender" (EnumType members) empty
             tT decl "type(Gender) is enum.EnumMeta"
             tT decl "set(Gender) == {Gender.male, Gender.female}"
             tT decl "Gender.male.value == 'male'"
@@ -542,8 +534,7 @@ spec = parallel $ do
                            , "katsuragi-misato"
                            , "nagisa-kaworu"
                            ] :: DeclarationSet EnumMember
-                decl' = TypeDeclaration "eva-char" (EnumType members') Nothing
-                                        empty
+                decl' = TypeDeclaration "eva-char" (EnumType members') empty
             tT decl' "type(EvaChar) is enum.EnumMeta"
             tT decl' "set(EvaChar) == {EvaChar.soryu_asuka_langley, \
                                      \ EvaChar.ayanami_rei, \
@@ -562,8 +553,7 @@ spec = parallel $ do
                          , Field "top" "bigint" Nothing
                          ]
                 payload = "{'_type': 'point', 'x': 3, 'top': 14}" :: T.Text
-                decl = TypeDeclaration "point" (RecordType fields) Nothing
-                                       empty
+                decl = TypeDeclaration "point" (RecordType fields) empty
             tT decl "isinstance(Point, type)"
             tT decl "Point(left=3, top=14).left == 3"
             tT decl "Point(left=3, top=14).top == 14"
@@ -587,8 +577,7 @@ spec = parallel $ do
                           , Field "top" "int-box" Nothing
                           ]
                 decls = [ Import ["foo", "bar"] "int-box"
-                        , TypeDeclaration "point" (RecordType fields') Nothing
-                                          empty
+                        , TypeDeclaration "point" (RecordType fields') empty
                         ]
                 payload' = "{'_type': 'point', 'left': 3, 'top': 14}" :: T.Text
             tT' decls "isinstance(Point, type)"
@@ -620,7 +609,6 @@ spec = parallel $ do
                 decls' = [ Import ["foo", "bar"] "point"
                          , TypeDeclaration "point3d"
                                            (RecordType fields'')
-                                           Nothing
                                            empty
                          ]
             tT' decls' "isinstance(Point3d, type)"
@@ -641,7 +629,7 @@ spec = parallel $ do
         specify "record type with one field" $ do
             let fields = [ Field "length" "bigint" Nothing ]
                 payload = "{'_type': 'line', 'length': 3}" :: T.Text
-                decl = TypeDeclaration "line" (RecordType fields) Nothing empty
+                decl = TypeDeclaration "line" (RecordType fields) empty
             tT decl "isinstance(Line, type)"
             tT decl "Line(length=10).length == 10"
             tT decl "Line.__slots__ == ('length', )"
@@ -664,7 +652,7 @@ spec = parallel $ do
                        , eastAsianNameTag
                        , cultureAgnosticNameTag
                        ]
-                decl = TypeDeclaration "name" (UnionType tags) Nothing empty
+                decl = TypeDeclaration "name" (UnionType tags) empty
             tT decl "isinstance(Name, type)"
             tT decl "Name.Tag.western_name.value == 'western_name'"
             tT decl "Name.Tag.east_asian_name.value == 'east_asian_name'"
@@ -751,7 +739,7 @@ spec = parallel $ do
                         [ Field "country" "text" Nothing ]
                         Nothing
                 tags = [cultureAgnosticNameTag]
-                decl = TypeDeclaration "music" (UnionType tags) Nothing empty
+                decl = TypeDeclaration "music" (UnionType tags) empty
             tT decl "Pop(country='KR').country == 'KR'"
             tT decl "Pop(country='KR') == Pop(country='KR')"
             tT decl "Pop(country='US') != Pop(country='KR')"
@@ -763,19 +751,16 @@ spec = parallel $ do
                         [ Field "country" "text" Nothing ]
                         Nothing
                 tags = [pop]
-                decl = TypeDeclaration "music" (UnionType tags) Nothing empty
+                decl = TypeDeclaration "music" (UnionType tags) empty
             tT decl "Pop(country='KR').__nirum_tag__.value == 'popular_music'"
         specify "service" $ do
-            let null' = ServiceDeclaration "null-service" (Service [])
-                                           Nothing empty
+            let null' = ServiceDeclaration "null-service" (Service []) empty
                 pingService = Service [Method "ping"
                                               [Parameter "nonce" "text" Nothing]
                                               "bool"
                                               Nothing
-                                              Nothing
                                               empty]
-                ping' = ServiceDeclaration "ping-service" pingService
-                                           Nothing empty
+                ping' = ServiceDeclaration "ping-service" pingService empty
             tT null' "issubclass(NullService, __import__('nirum').rpc.Service)"
             tT ping' "issubclass(PingService, __import__('nirum').rpc.Service)"
             tT ping' "set(PingService.ping.__annotations__) == \


### PR DESCRIPTION
This PR suggests to unify internal representations of doc comments and the annotation set, by treat doc comments as a `@doc("...")` annotation.