### PR TITLE
Escape some characters of annotation metadata

### DIFF
--- a/src/Nirum/Constructs/Annotation.hs
+++ b/src/Nirum/Constructs/Annotation.hs
@@ -10,6 +10,7 @@ module Nirum.Constructs.Annotation ( Annotation(Annotation)
                                    , toList
                                    ) where
 
+import qualified Data.Char as C
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import qualified Data.Text as T
@@ -27,8 +28,14 @@ data Annotation = Annotation { name :: Identifier
                              } deriving (Eq, Ord, Show)
 
 instance Construct Annotation where
-    toCode Annotation {name = n,  metadata = Just m} =
-        let m' = T.replace "\"" "\\\"" m in [qq|@{toCode n}("$m'")|]
+    toCode Annotation {name = n,  metadata = Just m} = [qq|@{toCode n}("$m'")|]
+      where
+        m' = (showLitString $ T.unpack m) ""
+        showLitString :: String -> ShowS
+        showLitString = foldr ((.) . showLitChar') id
+        showLitChar' :: Char -> ShowS
+        showLitChar' '"' = showString "\\\""
+        showLitChar' c   = C.showLitChar c
     toCode Annotation {name = n,  metadata = Nothing} = [qq|@{toCode n}|]
 
 data AnnotationSet

--- a/test/Nirum/ParserSpec.hs
+++ b/test/Nirum/ParserSpec.hs
@@ -178,6 +178,8 @@ spec = do
                 parse' "@ name-abc ( \"wo\\\"rld\")" `shouldBeRight`
                     rightAnnotaiton
                 parse' "@name-abc ( \"wo\\\"rld\")" `shouldBeRight` rightAnnotaiton
+                parse' "@name-abc(\"wo\\\"rld\\n\")" `shouldBeRight`
+                    Annotation "name-abc" (Just "wo\"rld\n")
             it "fails to parse if annotation name start with hyphen" $ do
                 expectError "@-abc(\"helloworld\")" 1 2
                 expectError "@-abc-d(\"helloworld\")" 1 2


### PR DESCRIPTION
It fixes the bug that `toCode` didn't escape some characters which can make the printed result can't parse, while converting `Annotation`.

Examples:

```
$ stack exec ghci
GHCi, version 8.0.1: http://www.haskell.org/ghc/  :? for help
Prelude> :seti -XOverloadedStrings
Prelude> import qualified Data.Text as T
Prelude T> import Nirum.Constructs.Annotation
Prelude T Nirum.Constructs.Annotation> let printCode = putStrLn . T.unpack . toCode
Prelude T Nirum.Constructs.Annotation> printCode $ Annotation "a" (Just "b\nc\td\"")
@a("b\nc\td\"")
```