### PR TITLE
Set -XOverloadedStrings globally and reduce {# LANGUAGE #} pragma

### DIFF
--- a/nirum.cabal
+++ b/nirum.cabal
@@ -46,6 +46,7 @@ library
                ,       text                     >=0.9.1.0 && <1.3
   hs-source-dirs:      src
   default-language:    Haskell2010
+  default-extensions:  OverloadedStrings
   ghc-options:         -Wall -Werror -fwarn-incomplete-uni-patterns
 
 executable nirum
@@ -85,6 +86,7 @@ test-suite spec
                ,       Nirum.Targets.PythonSpec
                ,       Nirum.VersionSpec
   default-language:    Haskell2010
+  default-extensions:  OverloadedStrings
   build-depends:       base                     >=4.7     && <5
                ,       containers               >=0.5.6.2 && <0.6
                ,       directory

--- a/src/Nirum/Cli.hs
+++ b/src/Nirum/Cli.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE ExtendedDefaultRules, OverloadedStrings, QuasiQuotes,
-             DeriveDataTypeable #-}
+{-# LANGUAGE ExtendedDefaultRules, QuasiQuotes, DeriveDataTypeable #-}
 module Nirum.Cli (main, writeFiles) where
 
 import Control.Monad (forM_)

--- a/src/Nirum/Constructs/Annotation.hs
+++ b/src/Nirum/Constructs/Annotation.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Nirum.Constructs.Annotation ( Annotation(Annotation)
                                    , AnnotationSet
                                    , Metadata

--- a/src/Nirum/Constructs/Annotation/Internal.hs
+++ b/src/Nirum/Constructs/Annotation/Internal.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, QuasiQuotes #-}
+{-# LANGUAGE QuasiQuotes #-}
 module Nirum.Constructs.Annotation.Internal ( Annotation(..)
                                             , AnnotationSet(..)
                                             , Metadata

--- a/src/Nirum/Constructs/Declaration.hs
+++ b/src/Nirum/Constructs/Declaration.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Nirum.Constructs.Declaration ( Declaration
                                     , Docs(Docs)
                                     , annotationDocsName

--- a/src/Nirum/Constructs/Identifier.hs
+++ b/src/Nirum/Constructs/Identifier.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedLists, OverloadedStrings #-}
+{-# LANGUAGE OverloadedLists #-}
 module Nirum.Constructs.Identifier ( Identifier
                                    , fromString
                                    , fromText

--- a/src/Nirum/Constructs/Module.hs
+++ b/src/Nirum/Constructs/Module.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedLists, OverloadedStrings, QuasiQuotes  #-}
+{-# LANGUAGE OverloadedLists, QuasiQuotes  #-}
 module Nirum.Constructs.Module ( Module(Module, docs, types)
                                , coreModule
                                , coreModulePath

--- a/src/Nirum/Constructs/ModulePath.hs
+++ b/src/Nirum/Constructs/ModulePath.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, TypeFamilies #-}
+{-# LANGUAGE TypeFamilies #-}
 module Nirum.Constructs.ModulePath ( ModulePath( ModuleName
                                                , ModulePath
                                                , moduleName

--- a/src/Nirum/Constructs/Name.hs
+++ b/src/Nirum/Constructs/Name.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Nirum.Constructs.Name ( Name(Name)
                              , behindName
                              , facialName

--- a/src/Nirum/Constructs/Service.hs
+++ b/src/Nirum/Constructs/Service.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Nirum.Constructs.Service ( Method ( Method
                                          , methodAnnotations
                                          , methodName

--- a/src/Nirum/Constructs/TypeDeclaration.hs
+++ b/src/Nirum/Constructs/TypeDeclaration.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Nirum.Constructs.TypeDeclaration ( EnumMember(EnumMember)
                                         , Field(Field)
                                         , JsonType(..)

--- a/src/Nirum/Constructs/TypeExpression.hs
+++ b/src/Nirum/Constructs/TypeExpression.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Nirum.Constructs.TypeExpression (TypeExpression(..), toCode) where
 
 import Data.String (IsString(fromString))

--- a/src/Nirum/Parser.hs
+++ b/src/Nirum/Parser.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, ScopedTypeVariables #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-warn-unused-do-bind #-}
 module Nirum.Parser ( Parser
                     , ParseError

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE ExtendedDefaultRules, OverloadedLists, OverloadedStrings,
-             QuasiQuotes #-}
+{-# LANGUAGE ExtendedDefaultRules, OverloadedLists, QuasiQuotes #-}
 module Nirum.Targets.Python ( Code
                             , CodeGen( code
                                      , localImports

--- a/test/Nirum/CliSpec.hs
+++ b/test/Nirum/CliSpec.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedLists, OverloadedStrings #-}
+{-# LANGUAGE OverloadedLists #-}
 module Nirum.CliSpec where
 
 import Control.Monad (forM_)

--- a/test/Nirum/Constructs/AnnotationSpec.hs
+++ b/test/Nirum/Constructs/AnnotationSpec.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedLists, OverloadedStrings #-}
+{-# LANGUAGE OverloadedLists #-}
 module Nirum.Constructs.AnnotationSpec where
 
 import Test.Hspec.Meta

--- a/test/Nirum/Constructs/DeclarationSetSpec.hs
+++ b/test/Nirum/Constructs/DeclarationSetSpec.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedLists, OverloadedStrings #-}
+{-# LANGUAGE OverloadedLists #-}
 module Nirum.Constructs.DeclarationSetSpec (SampleDecl(..), spec) where
 
 import Control.Exception.Base (evaluate)

--- a/test/Nirum/Constructs/DeclarationSpec.hs
+++ b/test/Nirum/Constructs/DeclarationSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Nirum.Constructs.DeclarationSpec where
 
 import Test.Hspec.Meta

--- a/test/Nirum/Constructs/IdentifierSpec.hs
+++ b/test/Nirum/Constructs/IdentifierSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Nirum.Constructs.IdentifierSpec where
 
 import Control.Exception (evaluate)

--- a/test/Nirum/Constructs/ModulePathSpec.hs
+++ b/test/Nirum/Constructs/ModulePathSpec.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedLists, OverloadedStrings #-}
+{-# LANGUAGE OverloadedLists #-}
 module Nirum.Constructs.ModulePathSpec where
 
 import Control.Exception (evaluate)

--- a/test/Nirum/Constructs/ModuleSpec.hs
+++ b/test/Nirum/Constructs/ModuleSpec.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedLists, OverloadedStrings, QuasiQuotes #-}
+{-# LANGUAGE OverloadedLists, QuasiQuotes #-}
 module Nirum.Constructs.ModuleSpec where
 
 import Test.Hspec.Meta

--- a/test/Nirum/Constructs/NameSpec.hs
+++ b/test/Nirum/Constructs/NameSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Nirum.Constructs.NameSpec where
 
 import Test.Hspec.Meta

--- a/test/Nirum/Constructs/ServiceSpec.hs
+++ b/test/Nirum/Constructs/ServiceSpec.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedLists, OverloadedStrings #-}
+{-# LANGUAGE OverloadedLists #-}
 module Nirum.Constructs.ServiceSpec where
 
 import Test.Hspec.Meta

--- a/test/Nirum/Constructs/TypeDeclarationSpec.hs
+++ b/test/Nirum/Constructs/TypeDeclarationSpec.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedLists, OverloadedStrings #-}
+{-# LANGUAGE OverloadedLists #-}
 module Nirum.Constructs.TypeDeclarationSpec where
 
 import Data.Either (rights)

--- a/test/Nirum/Constructs/TypeExpressionSpec.hs
+++ b/test/Nirum/Constructs/TypeExpressionSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Nirum.Constructs.TypeExpressionSpec where
 
 import Test.Hspec.Meta

--- a/test/Nirum/PackageSpec.hs
+++ b/test/Nirum/PackageSpec.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedLists, OverloadedStrings #-}
+{-# LANGUAGE OverloadedLists #-}
 module Nirum.PackageSpec where
 
 import Data.Either (isRight)

--- a/test/Nirum/ParserSpec.hs
+++ b/test/Nirum/ParserSpec.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedLists, OverloadedStrings, TypeFamilies #-}
+{-# LANGUAGE OverloadedLists, TypeFamilies #-}
 module Nirum.ParserSpec where
 
 import Control.Monad (forM_)

--- a/test/Nirum/Targets/PythonSpec.hs
+++ b/test/Nirum/Targets/PythonSpec.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE OverloadedLists, OverloadedStrings, QuasiQuotes,
-             ScopedTypeVariables #-}
+{-# LANGUAGE OverloadedLists, QuasiQuotes, ScopedTypeVariables #-}
 {-|
 This unit test module optionally depends on Python interpreter.
 It internally tries to popen python3 executable, and import nirum Python

--- a/test/Nirum/VersionSpec.hs
+++ b/test/Nirum/VersionSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Nirum.VersionSpec where
 
 import Data.Text (unpack)


### PR DESCRIPTION
`OverloadedStrings` GHC extension is used globally in Nirum source code, so most of files have `{# LANGUAGE OverloadedStrings #}` pragma. It's too repetitive so I suggest to make this extensions as a default and remove the pragmas.