### PR TITLE
Generalize CodeGen to use it for other targets

### DIFF
--- a/nirum.cabal
+++ b/nirum.cabal
@@ -19,6 +19,7 @@ cabal-version:       >=1.10
 
 library
   exposed-modules:     Nirum.Cli
+                 ,     Nirum.CodeGen
                  ,     Nirum.Constructs
                  ,     Nirum.Constructs.Annotation
                  ,     Nirum.Constructs.Annotation.Internal
@@ -73,6 +74,7 @@ test-suite spec
   hs-source-dirs:      test
   main-is:             Spec.hs
   other-modules:       Nirum.CliSpec
+               ,       Nirum.CodeGenSpec
                ,       Nirum.Constructs.AnnotationSpec
                ,       Nirum.Constructs.DocsSpec
                ,       Nirum.Constructs.DeclarationSetSpec

--- a/nirum.cabal
+++ b/nirum.cabal
@@ -43,6 +43,7 @@ library
                ,       filepath                 >=1.4     && <1.5
                ,       interpolatedstring-perl6 >=1.0.0   && <1.1.0
                ,       megaparsec               >=5       && <5.1
+               ,       mtl                      >=2.2.1   && <3
                ,       semver                   >=0.3.0   && <1.0
                ,       text                     >=0.9.1.0 && <1.3
   hs-source-dirs:      src
@@ -98,6 +99,7 @@ test-suite spec
                ,       hspec-meta
                ,       interpolatedstring-perl6 >=1.0.0   && <1.1.0
                ,       megaparsec               >=5       && <5.1
+               ,       mtl                      >=2.2.1   && <3
                ,       nirum
                ,       process                  >=1.1     && <2
                ,       semigroups

--- a/src/Nirum/CodeGen.hs
+++ b/src/Nirum/CodeGen.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+module Nirum.CodeGen ( CodeGen
+                     , runCodeGen
+                     ) where
+
+import Control.Applicative (Applicative)
+import Control.Monad (Monad)
+import Control.Monad.Except (MonadError)
+import Control.Monad.State (MonadState, StateT(StateT), runStateT)
+import Data.Functor (Functor)
+import Data.String (IsString, fromString)
+
+
+newtype (IsString e) => CodeGen c e a = CodeGen (StateT c (Either e) a)
+    deriving ( Applicative
+             , Functor
+             , MonadError e
+             , MonadState c
+             )
+
+instance (IsString e) => Monad (CodeGen c e) where
+    return a = CodeGen $ StateT $ \s -> return (a, s)
+    {-# INLINE return #-}
+    (CodeGen m) >>= k = CodeGen $ StateT $ \s -> do
+        ~(a, s') <- runStateT m s
+        let (CodeGen n) = k a
+        runStateT n s'
+    {-# INLINE (>>=) #-}
+    fail str = CodeGen $ StateT $ \_ -> Left $ fromString str
+    {-# INLINE fail #-}
+
+runCodeGen :: (IsString e) => CodeGen c e a -> c -> Either e (a, c)
+runCodeGen (CodeGen a) = runStateT a

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE ExtendedDefaultRules, OverloadedLists, QuasiQuotes #-}
 module Nirum.Targets.Python ( Code
-                            , CodeGen( code
-                                     , localImports
-                                     , standardImports
-                                     , thirdPartyImports
-                                     )
+                            , CodeGen
+                            , CodeGenContext ( localImports
+                                             , standardImports
+                                             , thirdPartyImports
+                                             )
                             , CompileError
                             , InstallRequires ( InstallRequires
                                               , dependencies
@@ -22,19 +22,21 @@ module Nirum.Targets.Python ( Code
                             , compilePrimitiveType
                             , compileTypeDeclaration
                             , compileTypeExpression
+                            , emptyContext
                             , hasError
                             , toAttributeName
                             , toClassName
                             , toImportPath
                             , toNamePair
                             , unionInstallRequires
-                            , withLocalImport
-                            , withStandardImport
-                            , withThirdPartyImports
+                            , insertLocalImport
+                            , insertStandardImport
+                            , insertThirdPartyImports
                             ) where
 
+import Control.Monad.State (StateT, modify, runStateT)
 import qualified Data.List as L
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, isJust)
 import GHC.Exts (IsList(toList))
 
 import qualified Data.Map.Strict as M
@@ -95,65 +97,46 @@ data Source = Source { sourcePackage :: Package
 type Code = T.Text
 type CompileError = T.Text
 
-data CodeGen a = CodeGen { standardImports :: S.Set T.Text
-                         , thirdPartyImports :: M.Map T.Text (S.Set T.Text)
-                         , localImports :: M.Map T.Text (S.Set T.Text)
-                         , code :: a
-                         }
-               | CodeGenError CompileError
-               deriving (Eq, Ord, Show)
+data CodeGenContext
+    = CodeGenContext { standardImports :: S.Set T.Text
+                     , thirdPartyImports :: M.Map T.Text (S.Set T.Text)
+                     , localImports :: M.Map T.Text (S.Set T.Text)
+                     }
+    deriving (Eq, Ord, Show)
 
-instance Functor CodeGen where
-    fmap f codeGen = pure f <*> codeGen
+emptyContext :: CodeGenContext
+emptyContext = CodeGenContext { standardImports = []
+                              , thirdPartyImports = []
+                              , localImports = []
+                              }
 
-instance Applicative CodeGen where
-    pure = return
-    c@CodeGen { code = f } <*> codeGen = codeGen >>= \x -> c { code = f x }
-    (CodeGenError m) <*> _ = CodeGenError m
-
-instance Monad CodeGen where
-    return code' = CodeGen { standardImports = []
-                           , thirdPartyImports = []
-                           , localImports = []
-                           , code = code'
-                           }
-    (CodeGen si ti li c) >>= f = case f c of
-        (CodeGen si' ti' li' code') ->
-            let stdImports = S.union si si'
-                thirdPartyImports' = M.unionWith S.union ti ti'
-                localImports' = M.unionWith S.union li li'
-            in
-                CodeGen stdImports thirdPartyImports' localImports' code'
-        (CodeGenError m) -> CodeGenError m
-    (CodeGenError m) >>= _ = CodeGenError m
-
-    fail = CodeGenError . T.pack
+type CodeGen = StateT CodeGenContext (Either CompileError)
 
 hasError :: CodeGen a -> Bool
-hasError (CodeGenError _) = True
-hasError _ = False
+hasError = isJust . compileError
 
 compileError :: CodeGen a -> Maybe CompileError
-compileError CodeGen {} = Nothing
-compileError (CodeGenError m) = Just m
+compileError codegen = (either Just (\_ -> Nothing)) $ runStateT codegen emptyContext
 
-withStandardImport :: T.Text -> CodeGen a -> CodeGen a
-withStandardImport module' c@CodeGen { standardImports = si } =
-    c { standardImports = S.insert module' si }
-withStandardImport _ c@(CodeGenError _) = c
-
-withThirdPartyImports :: [(T.Text, S.Set T.Text)] -> CodeGen a -> CodeGen a
-withThirdPartyImports imports c@CodeGen { thirdPartyImports = ti } =
-    c { thirdPartyImports = L.foldl (M.unionWith S.union) ti importList }
+insertStandardImport :: T.Text -> CodeGen ()
+insertStandardImport module' = modify insert'
   where
+    insert' c@CodeGenContext { standardImports = si } =
+        c { standardImports = S.insert module' si }
+
+insertThirdPartyImports :: [(T.Text, S.Set T.Text)] -> CodeGen ()
+insertThirdPartyImports imports = modify insert'
+  where
+    insert' c@CodeGenContext { thirdPartyImports = ti } =
+        c { thirdPartyImports = L.foldl (M.unionWith S.union) ti importList }
     importList :: [M.Map T.Text (S.Set T.Text)]
     importList = map (uncurry M.singleton) imports
-withThirdPartyImports _ c@(CodeGenError _) = c
 
-withLocalImport :: T.Text -> T.Text -> CodeGen a -> CodeGen a
-withLocalImport module' object c@CodeGen { localImports = li } =
-    c { localImports = M.insertWith S.union module' [object] li }
-withLocalImport _ _ c@(CodeGenError _) = c
+insertLocalImport :: T.Text -> T.Text -> CodeGen ()
+insertLocalImport module' object = modify insert'
+  where
+    insert' c@CodeGenContext { localImports = li } =
+        c { localImports = M.insertWith S.union module' [object] li }
 
 -- | The set of Python reserved keywords.
 -- See also: https://docs.python.org/3/reference/lexical_analysis.html#keywords
@@ -222,11 +205,11 @@ compileUnionTag source parentname typename' fields = do
             [name | Field name _ _ <- toList fields]
             ",\n        "
         parentClass = toClassName' parentname
-    withStandardImport "typing" $
-        withThirdPartyImports [ ("nirum.validate", ["validate_union_type"])
-                              , ("nirum.constructs", ["name_dict_type"])
-                              ] $
-            return [qq|
+    insertStandardImport "typing"
+    insertThirdPartyImports [ ("nirum.validate", ["validate_union_type"])
+                            , ("nirum.constructs", ["name_dict_type"])
+                            ]
+    return [qq|
 class $className($parentClass):
     # TODO: docstring
 
@@ -264,16 +247,16 @@ compilePrimitiveType primitiveTypeIdentifier =
     case primitiveTypeIdentifier of
         Bool -> return "bool"
         Bigint -> return "int"
-        Decimal -> withStandardImport "decimal" $ return "decimal.Decimal"
+        Decimal -> insertStandardImport "decimal" >> return "decimal.Decimal"
         Int32 -> return "int"
         Int64 -> return "int"
         Float32 -> return "float"
         Float64 -> return "float"
         Text -> return "str"
         Binary -> return "bytes"
-        Date -> withStandardImport "datetime" $ return "datetime.date"
-        Datetime -> withStandardImport "datetime" $ return "datetime.datetime"
-        Uuid -> withStandardImport "uuid" $ return"uuid.UUID"
+        Date -> insertStandardImport "datetime" >> return "datetime.date"
+        Datetime -> insertStandardImport "datetime" >> return "datetime.datetime"
+        Uuid -> insertStandardImport "uuid" >> return"uuid.UUID"
         Uri -> return "str"
 
 compileTypeExpression :: Source -> TypeExpression -> CodeGen Code
@@ -281,17 +264,19 @@ compileTypeExpression Source { sourceModule = boundModule } (TypeIdentifier i) =
     case lookupType i boundModule of
         Missing -> fail $ "undefined identifier: " ++ toString i
         Imported _ (PrimitiveType p _) -> compilePrimitiveType p
-        Imported m _ ->
-            withThirdPartyImports [(toImportPath m, [toClassName i])] $
-                return $ toClassName i
+        Imported m _ -> do
+            insertThirdPartyImports [(toImportPath m, [toClassName i])]
+            return $ toClassName i
         Local _ -> return $ toClassName i
 compileTypeExpression source (MapModifier k v) = do
     kExpr <- compileTypeExpression source k
     vExpr <- compileTypeExpression source v
-    withStandardImport "typing" $ return [qq|typing.Mapping[$kExpr, $vExpr]|]
+    insertStandardImport "typing"
+    return [qq|typing.Mapping[$kExpr, $vExpr]|]
 compileTypeExpression source modifier = do
     expr <- compileTypeExpression source typeExpr
-    withStandardImport "typing" $ return [qq|typing.$className[$expr]|]
+    insertStandardImport "typing"
+    return [qq|typing.$className[$expr]|]
   where
     typeExpr :: TypeExpression
     className :: T.Text
@@ -316,14 +301,12 @@ compileTypeDeclaration src TypeDeclaration { typename = typename'
                                            , type' = BoxedType itype } = do
     let className = toClassName' typename'
     itypeExpr <- compileTypeExpression src itype
-    withStandardImport "typing" $
-        withThirdPartyImports [ ("nirum.validate", ["validate_boxed_type"])
-                              , ("nirum.serialize", ["serialize_boxed_type"])
-                              , ( "nirum.deserialize"
-                                , ["deserialize_boxed_type"]
-                                )
-                              ] $
-            return [qq|
+    insertStandardImport "typing"
+    insertThirdPartyImports [ ("nirum.validate", ["validate_boxed_type"])
+                            , ("nirum.serialize", ["serialize_boxed_type"])
+                            , ("nirum.deserialize", ["deserialize_boxed_type"])
+                            ]
+    return [qq|
 class $className:
     # TODO: docstring
 
@@ -360,7 +343,8 @@ compileTypeDeclaration _ TypeDeclaration { typename = typename'
             [ [qq|{toAttributeName' memberName} = '{toSnakeCaseText bn}'|]
             | EnumMember memberName@(Name _ bn) _ <- toList members
             ]
-    withStandardImport "enum" $ return [qq|
+    insertStandardImport "enum"
+    return [qq|
 class $className(enum.Enum):
     # TODO: docstring
 
@@ -393,16 +377,13 @@ compileTypeDeclaration src TypeDeclaration { typename = typename'
             toNamePair
             [name | Field name _ _ <- toList fields]
             ",\n        "
-    withStandardImport "typing" $
-        withThirdPartyImports [ ( "nirum.validate"
-                                , ["validate_record_type"]
-                                )
-                              , ("nirum.serialize", ["serialize_record_type"])
-                              , ( "nirum.deserialize"
-                                , ["deserialize_record_type"])
-                              , ("nirum.constructs", ["name_dict_type"])
-                              ] $
-            return [qq|
+    insertStandardImport "typing"
+    insertThirdPartyImports [ ("nirum.validate", ["validate_record_type"])
+                            , ("nirum.serialize", ["serialize_record_type"])
+                            , ("nirum.deserialize", ["deserialize_record_type"])
+                            , ("nirum.constructs", ["name_dict_type"])
+                            ]
+    return [qq|
 class $className:
     # TODO: docstring
 
@@ -448,15 +429,13 @@ compileTypeDeclaration src TypeDeclaration { typename = typename'
         fieldCodes' = T.intercalate "\n\n" fieldCodes
         enumMembers = toIndentedCodes
             (\(t, b) -> [qq|$t = '{b}'|]) enumMembers' "\n        "
-    withStandardImport "typing" $
-        withStandardImport "enum" $
-            withThirdPartyImports [ ( "nirum.serialize"
-                                    , ["serialize_union_type"])
-                                  , ( "nirum.deserialize"
-                                    , ["deserialize_union_type"])
-                                  , ("nirum.constructs", ["name_dict_type"])
-                                  ] $
-                return [qq|
+    insertStandardImport "typing"
+    insertStandardImport "enum"
+    insertThirdPartyImports [ ("nirum.serialize", ["serialize_union_type"])
+                            , ("nirum.deserialize", ["deserialize_union_type"])
+                            , ("nirum.constructs", ["name_dict_type"])
+                            ]
+    return [qq|
 class $className:
 
     __nirum_union_behind_name__ = '{toSnakeCaseText $ N.behindName typename'}'
@@ -511,16 +490,16 @@ compileTypeDeclaration src ServiceDeclaration { serviceName = name
     clientMethods <- mapM compileClientMethod methods'
     let dummyMethods' = T.intercalate "\n\n" dummyMethods
         clientMethods' = T.intercalate "\n\n" clientMethods
-    withStandardImport "urllib.request" $
-        withStandardImport "json" $
-            withThirdPartyImports [ ("nirum.constructs", ["name_dict_type"])
-                                  , ("nirum.deserialize", ["deserialize_meta"])
-                                  , ("nirum.serialize", ["serialize_meta"])
-                                  , ("nirum.rpc", [ "service_type"
-                                                  , "client_type"
-                                                  ])
-                                  ] $
-                return [qq|
+    insertStandardImport "urllib.request"
+    insertStandardImport "json"
+    insertThirdPartyImports [ ("nirum.constructs", ["name_dict_type"])
+                            , ("nirum.deserialize", ["deserialize_meta"])
+                            , ("nirum.serialize", ["serialize_meta"])
+                            , ("nirum.rpc", [ "service_type"
+                                            , "client_type"
+                                            ])
+                            ]
+    return [qq|
 class $className(service_type):
 
     __nirum_service_methods__ = \{
@@ -566,12 +545,12 @@ class {className}_Client(client_type, $className):
         rtypeExpr <- compileTypeExpression src rtype
         paramMetadata <- mapM compileParameterMetadata params'
         let paramMetadata' = commaNl paramMetadata
-        withThirdPartyImports [("nirum.constructs", ["name_dict_type"])] $
-            return [qq|'{toAttributeName' mName}': \{
-                '_return': $rtypeExpr,
-                '_names': name_dict_type([{paramNameMap params'}]),
-                {paramMetadata'}
-            \}|]
+        insertThirdPartyImports [("nirum.constructs", ["name_dict_type"])]
+        return [qq|'{toAttributeName' mName}': \{
+            '_return': $rtypeExpr,
+            '_names': name_dict_type([{paramNameMap params'}]),
+            {paramMetadata'}
+        \}|]
     compileParameterMetadata :: Parameter -> CodeGen Code
     compileParameterMetadata (Parameter pName pType _) = do
         let pName' = toAttributeName' pName
@@ -656,17 +635,18 @@ unionInstallRequires a b =
 
 compileModule :: Source -> Either CompileError (InstallRequires, Code)
 compileModule source =
-    case code' of
-        CodeGenError errMsg -> Left errMsg
-        CodeGen {} -> codeWithDeps $ [qq|
-{imports $ standardImports code'}
+    case runStateT code' emptyContext of
+        Left errMsg -> Left errMsg
+        Right (code, context) -> do
+            codeWithDeps context $ [qq|
+                {imports $ standardImports context}
 
-{fromImports $ localImports code'}
+                {fromImports $ localImports context}
 
-{fromImports $ thirdPartyImports code'}
+                {fromImports $ thirdPartyImports context}
 
-{code code'}
-    |]
+                {code}
+            |]
   where
     code' :: CodeGen T.Text
     code' = compileModuleBody source
@@ -687,14 +667,16 @@ compileModule source =
     require :: T.Text -> T.Text -> S.Set T.Text -> S.Set T.Text
     require pkg module' set =
         if set `has` module' then S.singleton pkg else S.empty
-    deps :: S.Set T.Text
-    deps = require "nirum" "nirum" $ M.keysSet $ thirdPartyImports code'
-    optDeps :: M.Map (Int, Int) (S.Set T.Text)
-    optDeps = [ ((3, 4), require "enum34" "enum" $ standardImports code')
-              , ((3, 5), require "typing" "typing" $ standardImports code')
-              ]
-    codeWithDeps :: Code -> Either CompileError (InstallRequires, Code)
-    codeWithDeps c = Right (InstallRequires deps optDeps, c)
+    codeWithDeps :: CodeGenContext -> Code -> Either CompileError (InstallRequires, Code)
+    codeWithDeps context c = Right (InstallRequires deps optDeps, c)
+      where
+        deps :: S.Set T.Text
+        deps = require "nirum" "nirum" $ M.keysSet $ thirdPartyImports context
+        optDeps :: M.Map (Int, Int) (S.Set T.Text)
+        optDeps =
+            [ ((3, 4), require "enum34" "enum" $ standardImports context)
+            , ((3, 5), require "typing" "typing" $ standardImports context)
+            ]
 
 compilePackageMetadata :: Package -> InstallRequires -> Code
 compilePackageMetadata package (InstallRequires deps optDeps) = [qq|

--- a/test/Nirum/CodeGenSpec.hs
+++ b/test/Nirum/CodeGenSpec.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+module Nirum.CodeGenSpec where
+
+import Control.Monad.Except (throwError)
+import Control.Monad.State (modify)
+import Data.Text (Text)
+
+import Test.Hspec.Meta
+
+import Nirum.CodeGen (CodeGen, runCodeGen)
+
+
+spec :: Spec
+spec = parallel $ do
+    describe "CodeGen" $ do
+        specify "fail" $ do
+            let codeGen' :: CodeGen Integer String () = do
+                    modify (+1)
+                    modify (+1)
+                    fail "test"
+            runCodeGen codeGen' 0 `shouldBe` Left "test"
+            let codeGen'' :: CodeGen Integer String Integer = do
+                    modify (+1)
+                    fail "test"
+                    modify (+1)
+                    return 42
+            runCodeGen codeGen'' 0 `shouldBe` Left "test"
+        specify "throwError" $ do
+            let codeGen' :: CodeGen Integer (Maybe Text) () = do
+                    throwError $ Just "test"
+            runCodeGen codeGen' 0 `shouldBe` Left (Just "test")

--- a/test/Nirum/CodeGenSpec.hs
+++ b/test/Nirum/CodeGenSpec.hs
@@ -1,31 +1,39 @@
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleInstances, ScopedTypeVariables, RankNTypes, MultiParamTypeClasses #-}
 module Nirum.CodeGenSpec where
 
 import Control.Monad.Except (throwError)
 import Control.Monad.State (modify)
-import Data.Text (Text)
+import Data.Text as T (Text, pack)
 
 import Test.Hspec.Meta
 
-import Nirum.CodeGen (CodeGen, runCodeGen)
+import Nirum.CodeGen (CodeGen, Failure, fromString, runCodeGen)
+
+
+data SampleError = SampleError Text
+    deriving (Eq, Ord, Show)
+
+instance forall s. Failure s SampleError where
+    fromString = return . SampleError . T.pack
 
 
 spec :: Spec
 spec = parallel $ do
-    describe "CodeGen" $ do
-        specify "fail" $ do
-            let codeGen' :: CodeGen Integer String () = do
-                    modify (+1)
-                    modify (+1)
-                    fail "test"
-            runCodeGen codeGen' 0 `shouldBe` Left "test"
-            let codeGen'' :: CodeGen Integer String Integer = do
-                    modify (+1)
-                    fail "test"
-                    modify (+1)
-                    return 42
-            runCodeGen codeGen'' 0 `shouldBe` Left "test"
-        specify "throwError" $ do
-            let codeGen' :: CodeGen Integer (Maybe Text) () = do
-                    throwError $ Just "test"
-            runCodeGen codeGen' 0 `shouldBe` Left (Just "test")
+    specify "fail" $ do
+        let codeGen' :: CodeGen Integer SampleError () = do
+                modify (+1)
+                modify (+1)
+                fail "test"
+        runCodeGen codeGen' 0 `shouldBe` (Left (SampleError "test"), 2)
+        let codeGen'' :: CodeGen Integer SampleError Integer = do
+                modify (+1)
+                _ <- fail "test"
+                modify (+1)
+                return 42
+        runCodeGen codeGen'' 0 `shouldBe` (Left (SampleError "test"), 1)
+    specify "throwError" $ do
+        let codeGen' :: CodeGen Integer SampleError () = do
+                modify (+1)
+                _ <- throwError $ SampleError "test"
+                modify (+2)
+        runCodeGen codeGen' 0 `shouldBe` (Left (SampleError "test"), 1)

--- a/test/Nirum/Targets/PythonSpec.hs
+++ b/test/Nirum/Targets/PythonSpec.hs
@@ -18,7 +18,6 @@ run this unit test in the virtualenv (pyvenv).  E.g.:
 module Nirum.Targets.PythonSpec where
 
 import Control.Monad (forM_, void, unless)
-import Control.Monad.Except (throwError)
 import Data.Char (isSpace)
 import Data.Maybe (fromJust, isJust)
 import System.IO.Error (catchIOError)
@@ -91,7 +90,6 @@ import Nirum.Targets.Python ( Source (Source)
                                               )
                             , addDependency
                             , addOptionalDependency
-                            , compileError
                             , compilePackage
                             , compilePrimitiveType
                             , compileTypeExpression
@@ -297,6 +295,10 @@ code = fst . run'
 codeContext :: CodeGen a -> CodeGenContext
 codeContext = snd . run'
 
+compileError :: CodeGen a -> Maybe CompileError
+compileError cg = either Just (const Nothing) $ runCodeGen cg emptyContext
+
+
 spec :: Spec
 spec = parallel $ do
     describe "CodeGen" $ do
@@ -330,18 +332,6 @@ spec = parallel $ do
             thirdPartyImports ctx2 `shouldBe` []
             localImports ctx2 `shouldBe` []
             compileError codeGen2 `shouldBe` Nothing
-        specify "fail" $ do
-            let codeGen' = do
-                    insertStandardImport "sys"
-                    _ <- fail "test"
-                    insertStandardImport "sys"
-            compileError codeGen' `shouldBe` Just "test"
-        specify "throwError" $ do
-            let codeGen' = do
-                    insertStandardImport "sys"
-                    _ <- throwError "test"
-                    insertStandardImport "sys"
-            compileError codeGen' `shouldBe` Just "test"
 
     specify "compilePrimitiveType" $ do
         code (compilePrimitiveType Bool) `shouldBe` "bool"

--- a/test/Nirum/Targets/PythonSpec.hs
+++ b/test/Nirum/Targets/PythonSpec.hs
@@ -18,6 +18,7 @@ run this unit test in the virtualenv (pyvenv).  E.g.:
 module Nirum.Targets.PythonSpec where
 
 import Control.Monad (forM_, void, unless)
+import Control.Monad.Except (throwError)
 import Data.Char (isSpace)
 import Data.Maybe (fromJust, isJust)
 import System.IO.Error (catchIOError)
@@ -333,6 +334,12 @@ spec = parallel $ do
             let codeGen' = do
                     insertStandardImport "sys"
                     _ <- fail "test"
+                    insertStandardImport "sys"
+            compileError codeGen' `shouldBe` Just "test"
+        specify "throwError" $ do
+            let codeGen' = do
+                    insertStandardImport "sys"
+                    _ <- throwError "test"
                     insertStandardImport "sys"
             compileError codeGen' `shouldBe` Just "test"
 

--- a/test/Nirum/Targets/PythonSpec.hs
+++ b/test/Nirum/Targets/PythonSpec.hs
@@ -18,10 +18,12 @@ run this unit test in the virtualenv (pyvenv).  E.g.:
 module Nirum.Targets.PythonSpec where
 
 import Control.Monad (forM_, void, unless)
+import Control.Monad.State (runStateT)
 import Data.Char (isSpace)
 import Data.Maybe (fromJust, isJust)
 import System.IO.Error (catchIOError)
 
+import Data.Either (isRight)
 import Data.List (dropWhileEnd)
 import qualified Data.Map.Strict as M
 import qualified Data.Text as T
@@ -77,11 +79,11 @@ import Nirum.Package (BoundModule(modulePath), Package, resolveBoundModule)
 import Nirum.PackageSpec (createPackage)
 import Nirum.Targets.Python ( Source (Source)
                             , Code
-                            , CodeGen( code
-                                     , localImports
-                                     , standardImports
-                                     , thirdPartyImports
-                                     )
+                            , CodeGen
+                            , CodeGenContext ( localImports
+                                             , standardImports
+                                             , thirdPartyImports
+                                             )
                             , CompileError
                             , InstallRequires ( InstallRequires
                                               , dependencies
@@ -93,15 +95,15 @@ import Nirum.Targets.Python ( Source (Source)
                             , compilePackage
                             , compilePrimitiveType
                             , compileTypeExpression
-                            , hasError
+                            , emptyContext
                             , toAttributeName
                             , toClassName
                             , toImportPath
                             , toNamePair
                             , unionInstallRequires
-                            , withLocalImport
-                            , withStandardImport
-                            , withThirdPartyImports
+                            , insertLocalImport
+                            , insertStandardImport
+                            , insertThirdPartyImports
                             )
 
 codeGen :: a -> CodeGen a
@@ -283,141 +285,111 @@ makeDummySource' pathPrefix m =
 makeDummySource :: Module -> Source
 makeDummySource = makeDummySource' []
 
+run' :: CodeGen a -> (a, CodeGenContext)
+run' c = case runStateT c emptyContext of
+    Left errMsg  -> error $ T.unpack errMsg
+    Right a      -> a
+
+code :: CodeGen a -> a
+code = fst . run'
+
+codeContext :: CodeGen a -> CodeGenContext
+codeContext = snd . run'
+
 spec :: Spec
 spec = parallel $ do
     describe "CodeGen" $ do
-        let v = 123 :: Int
-            cg = return v :: CodeGen Int
-            f = return . g :: Int -> CodeGen Int
-            f' = return . h :: Int -> CodeGen Int
-            g = (+ 5) :: Int -> Int
-            h = (* 2) :: Int -> Int
-            g' = pure g :: CodeGen (Int -> Int)
-            h' = pure h :: CodeGen (Int -> Int)
-            id' x = x
-        context "Functor" $ do
-            specify "identity morphisms" $
-                fmap id' (return 123 :: CodeGen Int) `shouldBe` id' (return 123)
-            specify "composition of morphisms" $ do
-                fmap (g . h) cg `shouldBe` (fmap g . fmap h) cg
-                fmap (h . g) cg `shouldBe` (fmap h . fmap g) cg
-        context "Applicative" $ do
-            specify "identity law" $
-                (pure id' <*> cg) `shouldBe` cg
-            specify "homomorphism" $ do
-                let pure' = pure :: a -> CodeGen a
-                (pure g <*> pure v) `shouldBe` pure' (g v)
-                (pure h <*> pure v) `shouldBe` pure' (h v)
-            specify "interchange" $ do
-                (g' <*> pure v) `shouldBe` (pure ($ v) <*> g')
-                (h' <*> pure v) `shouldBe` (pure ($ v) <*> h')
-            specify "composition" $ do
-                (g' <*> (h' <*> cg)) `shouldBe` (pure (.) <*> g' <*> h' <*> cg)
-                (h' <*> (g' <*> cg)) `shouldBe` (pure (.) <*> h' <*> g' <*> cg)
         context "Monad" $ do
-            specify "left identity" $ do
-                (return v >>= f) `shouldBe` f v
-                (return v >>= f') `shouldBe` f' v
-            specify "right identity" $
-                (cg >>= return) `shouldBe` cg
-            specify "associativity" $ do
-                ((cg >>= f) >>= f') `shouldBe` (cg >>= (\x -> f x >>= f'))
-                ((cg >>= f') >>= f) `shouldBe` (cg >>= (\x -> f' x >>= f))
             specify "packages and imports" $ do
-                let (c :: CodeGen Int) = do
-                        a <- withStandardImport "sys" cg
-                        b <- withThirdPartyImports
-                            [("nirum", ["serialize_boxed_type"])]
-                            cg
-                        c' <- withLocalImport ".." "Gender" cg
-                        d <- withStandardImport "os" cg
-                        e <- withThirdPartyImports
-                            [("nirum", ["serialize_enum_type"])]
-                            cg
-                        f'' <- withLocalImport ".." "Path" cg
-                        return $ sum ([a, b, c', d, e, f''] :: [Int])
-                c `shouldSatisfy` (not . hasError)
-                standardImports c `shouldBe` ["os", "sys"]
-                thirdPartyImports c `shouldBe`
+                let c = do
+                        insertStandardImport "sys"
+                        insertThirdPartyImports [("nirum", ["serialize_boxed_type"])]
+                        insertLocalImport ".." "Gender"
+                        insertStandardImport "os"
+                        insertThirdPartyImports [("nirum", ["serialize_enum_type"])]
+                        insertLocalImport ".." "Path"
+                runStateT c emptyContext `shouldSatisfy` isRight
+                let Right (_, ctx) = runStateT c emptyContext
+                standardImports ctx `shouldBe` ["os", "sys"]
+                thirdPartyImports ctx `shouldBe`
                     [("nirum", ["serialize_boxed_type", "serialize_enum_type"])]
-                localImports c `shouldBe` [("..", ["Gender", "Path"])]
-                code c `shouldBe` (123 * 6)
-        specify "withStandardImport" $ do
-            let codeGen1 = withStandardImport "sys" (pure True)
-            codeGen1 `shouldSatisfy` (not . hasError)
-            standardImports codeGen1 `shouldBe` ["sys"]
-            thirdPartyImports codeGen1 `shouldBe` []
-            localImports codeGen1 `shouldBe` []
-            code codeGen1 `shouldBe` True
+                localImports ctx `shouldBe` [("..", ["Gender", "Path"])]
+        specify "insertStandardImport" $ do
+            let codeGen1 = insertStandardImport "sys"
+            runStateT codeGen1 emptyContext `shouldSatisfy` isRight
+            let Right (_, ctx1) = runStateT codeGen1 emptyContext
+            standardImports ctx1 `shouldBe` ["sys"]
+            thirdPartyImports ctx1 `shouldBe` []
+            localImports ctx1 `shouldBe` []
             compileError codeGen1 `shouldBe` Nothing
-            let codeGen2 = withStandardImport "os" codeGen1
-            codeGen2 `shouldSatisfy` (not . hasError)
-            standardImports codeGen2 `shouldBe` ["os", "sys"]
-            thirdPartyImports codeGen2 `shouldBe` []
-            localImports codeGen2 `shouldBe` []
-            code codeGen2 `shouldBe` True
+            let codeGen2 = codeGen1 >> insertStandardImport "os"
+            runStateT codeGen2 emptyContext `shouldSatisfy` isRight
+            let Right (_, ctx2) = runStateT codeGen2 emptyContext
+            standardImports ctx2 `shouldBe` ["os", "sys"]
+            thirdPartyImports ctx2 `shouldBe` []
+            localImports ctx2 `shouldBe` []
             compileError codeGen2 `shouldBe` Nothing
         specify "fail" $ do
             let codeGen' = do
-                    val <- withStandardImport "sys" (pure True)
+                    insertStandardImport "sys"
                     _ <- fail "test"
-                    withStandardImport "sys" (pure val)
+                    insertStandardImport "sys"
             compileError codeGen' `shouldBe` Just "test"
 
     specify "compilePrimitiveType" $ do
         code (compilePrimitiveType Bool) `shouldBe` "bool"
         code (compilePrimitiveType Bigint) `shouldBe` "int"
-        let decimal = compilePrimitiveType Decimal
-        code decimal `shouldBe` "decimal.Decimal"
-        standardImports decimal `shouldBe` ["decimal"]
+        let (decimalCode, decimalContext) = run' (compilePrimitiveType Decimal)
+        decimalCode `shouldBe` "decimal.Decimal"
+        standardImports decimalContext `shouldBe` ["decimal"]
         code (compilePrimitiveType Int32) `shouldBe` "int"
         code (compilePrimitiveType Int64) `shouldBe` "int"
         code (compilePrimitiveType Float32) `shouldBe` "float"
         code (compilePrimitiveType Float64) `shouldBe` "float"
         code (compilePrimitiveType Text) `shouldBe` "str"
         code (compilePrimitiveType Binary) `shouldBe` "bytes"
-        let date = compilePrimitiveType Date
-        code date `shouldBe` "datetime.date"
-        standardImports date `shouldBe` ["datetime"]
-        let datetime = compilePrimitiveType Datetime
-        code datetime `shouldBe` "datetime.datetime"
-        standardImports datetime `shouldBe` ["datetime"]
-        let uuid = compilePrimitiveType Uuid
-        code uuid `shouldBe` "uuid.UUID"
-        standardImports uuid `shouldBe` ["uuid"]
+        let (dateCode, dateContext) = run' (compilePrimitiveType Date)
+        dateCode `shouldBe` "datetime.date"
+        standardImports dateContext `shouldBe` ["datetime"]
+        let (datetimeCode, datetimeContext) = run' (compilePrimitiveType Datetime)
+        datetimeCode `shouldBe` "datetime.datetime"
+        standardImports datetimeContext `shouldBe` ["datetime"]
+        let (uuidCode, uuidContext) = run' (compilePrimitiveType Uuid)
+        uuidCode `shouldBe` "uuid.UUID"
+        standardImports uuidContext `shouldBe` ["uuid"]
         code (compilePrimitiveType Uri) `shouldBe` "str"
 
     describe "compileTypeExpression" $ do
         let s = makeDummySource $ Module [] Nothing
         specify "TypeIdentifier" $ do
             let c = compileTypeExpression s (TypeIdentifier "bigint")
-            c `shouldSatisfy` (not . hasError)
-            standardImports c `shouldBe` []
-            localImports c `shouldBe` []
+            runStateT c emptyContext `shouldSatisfy` isRight
+            standardImports (codeContext c) `shouldBe` []
+            localImports (codeContext c) `shouldBe` []
             code c `shouldBe` "int"
         specify "OptionModifier" $ do
             let c' = compileTypeExpression s (OptionModifier "text")
-            c' `shouldSatisfy` (not . hasError)
-            standardImports c' `shouldBe` ["typing"]
-            localImports c' `shouldBe` []
+            runStateT c' emptyContext `shouldSatisfy` isRight
+            standardImports (codeContext c') `shouldBe` ["typing"]
+            localImports (codeContext c') `shouldBe` []
             code c' `shouldBe` "typing.Optional[str]"
         specify "SetModifier" $ do
             let c'' = compileTypeExpression s (SetModifier "text")
-            c'' `shouldSatisfy` (not . hasError)
-            standardImports c'' `shouldBe` ["typing"]
-            localImports c'' `shouldBe` []
+            runStateT c'' emptyContext `shouldSatisfy` isRight
+            standardImports (codeContext c'') `shouldBe` ["typing"]
+            localImports (codeContext c'') `shouldBe` []
             code c'' `shouldBe` "typing.AbstractSet[str]"
         specify "ListModifier" $ do
             let c''' = compileTypeExpression s (ListModifier "text")
-            c''' `shouldSatisfy` (not . hasError)
-            standardImports c''' `shouldBe` ["typing"]
-            localImports c''' `shouldBe` []
+            runStateT c''' emptyContext `shouldSatisfy` isRight
+            standardImports (codeContext c''') `shouldBe` ["typing"]
+            localImports (codeContext c''') `shouldBe` []
             code c''' `shouldBe` "typing.Sequence[str]"
         specify "MapModifier" $ do
             let c'''' = compileTypeExpression s (MapModifier "uuid" "text")
-            c'''' `shouldSatisfy` (not . hasError)
-            standardImports c'''' `shouldBe` ["uuid", "typing"]
-            localImports c'''' `shouldBe` []
+            runStateT c'''' emptyContext `shouldSatisfy` isRight
+            standardImports (codeContext c'''') `shouldBe` ["uuid", "typing"]
+            localImports (codeContext c'''') `shouldBe` []
             code c'''' `shouldBe` "typing.Mapping[uuid.UUID, str]"
 
     describe "toClassName" $ do


### PR DESCRIPTION
This is a preparation of #50, to insert the information which version of Python code will be generated, in the code generation progress.