### PR TITLE
Allow spaces right before/after tag parentheses

### DIFF
--- a/src/Nirum/Parser.hs
+++ b/src/Nirum/Parser.hs
@@ -412,7 +412,9 @@ tag = do
     spaces
     paren <- optional $ char '('
     fields' <- case paren of
-        Just _ -> do { f <- fieldSet <?> "union tag fields"
+        Just _ -> do { spaces
+                     ; f <- fieldSet <?> "union tag fields"
+                     ; spaces
                      ; char ')'
                      ; return f
                      }

--- a/test/Nirum/ParserSpec.hs
+++ b/test/Nirum/ParserSpec.hs
@@ -607,6 +607,17 @@ spec = do
                    \    | none\n\
                    \    ;" `shouldBeRight` a
             parse' "union shape\n\
+                   \    = circle (\n\
+                   \        point origin,\n\
+                   \        offset radius,\n\
+                   \      )\n\
+                   \    | rectangle (\n\
+                   \        point upper-left,\n\
+                   \        point lower-right,\n\
+                   \      )\n\
+                   \    | none\n\
+                   \    ;" `shouldBeRight` a
+            parse' "union shape\n\
                    \    # shape type\n\
                    \    = circle (point origin, \
                                  \offset radius,)\n\


### PR DESCRIPTION
This patch fixes #69.

The parser previously has a bug disallowing any whitespaces (including newline) right before and right after `union` tags' parentheses.  For example, the previous parser doesn't accept the following `union` declaration:

```nirum
union shape
    = circle (  // ⬅️ Newline/whitespaces not allowed ➡️
        point origin,
        offset radius,
        // ⬅️ Newline/whitespaces not allowed ➡️
      )
    | rectangle (  // ⬅️ Newline/whitespaces not allowed ➡️
        point upper-left,
        point lower-right,
        // ⬅️ Newline/whitespaces not allowed ➡️
    )
    | none
    ;
```