### PR TITLE
Fix AppVeyor's broken pip upgrade

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ install:
 - C:\Python35\python -m venv C:\pyvenv
 - >
     C:\pyvenv\Scripts\Activate.bat &
-    pip install --upgrade setuptools pip &
+    python -m pip install --upgrade setuptools pip &
     pip install git+git://github.com/spoqa/nirum-python.git
 build_script:
 - stack --no-terminal build --copy-bins


### PR DESCRIPTION
Since Windows disallows to delete running exeuctables, `pip install --upgrade pip` can't replace `pip` itself.  To workaround this, we should use `python -m pip` command instead of `pip`.

See also the issue pypa/pip#1299.
