### PR TITLE
Hotfix of incompatibility with upstream nirum-python

### DIFF
--- a/test/Nirum/Targets/PythonSpec.hs
+++ b/test/Nirum/Targets/PythonSpec.hs
@@ -504,7 +504,11 @@ spec = parallel $ do
             tT decl "FloatBox.__nirum_deserialize__(3.14) == FloatBox(3.14)"
             tT decl "hash(FloatBox(3.14))"
             tT decl "hash(FloatBox(3.14)) != 3.14"
-            tR' decl "TypeError" "FloatBox.__nirum_deserialize__('a')"
+            -- FIXME: Is TypeError/ValueError is appropriate exception type
+            -- for deserialization error?  For such case, json.loads() raises
+            -- JSONDecodeError (which inherits ValueError).
+            tR' decl "(TypeError, ValueError)"
+                     "FloatBox.__nirum_deserialize__('a')"
             tR' decl "TypeError" "FloatBox('a')"
             let decls = [ Import ["foo", "bar"] "path-box" empty
                         , TypeDeclaration "imported-type-box"
@@ -532,7 +536,11 @@ spec = parallel $ do
                 ImportedTypeBox.__nirum_deserialize__('/path/string') ==
                 ImportedTypeBox(PathBox('/path/string'))
             |]
-            tR'' decls "TypeError" "ImportedTypeBox.__nirum_deserialize__(123)"
+            -- FIXME: Is TypeError/ValueError is appropriate exception type
+            -- for deserialization error?  For such case, json.loads() raises
+            -- JSONDecodeError (which inherits ValueError).
+            tR'' decls "(TypeError, ValueError)"
+                       "ImportedTypeBox.__nirum_deserialize__(123)"
             tR'' decls "TypeError" "ImportedTypeBox(123)"
             let boxedAlias = [ Import ["qux"] "path" empty
                              , TypeDeclaration "way"


### PR DESCRIPTION
Although [raising `ValueError`/`TypeError` seems inappropriate for deserialization errors][1], I created a hotfix of incompatibility with upstream nirum-python.  This incompatibility blocks #78 and #79 to be merged by breaking CI builds.

[1]: https://gitter.im/spoqa/nirum?at=57e2df5818291e10488f32c3