### PR TITLE
Rename boxed to unboxed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ install:
     if [[ ! -f "$HOME/.pyvenv/bin/activate" ]]; then virtualenv -p "$(which python$PY)" "$HOME/.pyvenv"; fi
   fi
 - '"$HOME/.pyvenv/bin/pip" install --upgrade pip setuptools'
-- '"$HOME/.pyvenv/bin/pip" install git+git://github.com/spoqa/nirum-python.git'
+- '"$HOME/.pyvenv/bin/pip" install --upgrade git+git://github.com/spoqa/nirum-python.git'
 - if [[ "$PY" = "3.4" ]]; then "$HOME/.pyvenv/bin/pip" install --upgrade typing; fi  # FIXME
 - 'sed -E "s/resolver\s*:\s*.*/resolver: $RESOLVER/" stack.yaml > stack-new.yaml'
 - mv stack-new.yaml stack.yaml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ install:
 - >
     C:\pyvenv\Scripts\Activate.bat &
     python -m pip install --upgrade setuptools pip &
-    pip install git+git://github.com/spoqa/nirum-python.git
+    pip install --upgrade git+git://github.com/spoqa/nirum-python.git
 build_script:
 - stack --no-terminal build --copy-bins
 after_build:

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -86,13 +86,13 @@ It's represented in JSON to:
     }
 
 
-Boxed type
-----------
+Unboxed type
+------------
 
-Boxed type is equivalent to 1-member record type in runtime, but it's equivalent
-to its internal type in JSON representation.  For example:
+Unboxed type is equivalent to 1-member record type in runtime,
+but it's equivalent to its internal type in JSON representation.  For example:
 
-    boxed offset (float64);
+    unboxed offset (float64);
 
     record payload (
         offset left,
@@ -112,7 +112,7 @@ The internal type might be a record type as well:
         float64 top,
     );
 
-    boxed coord (point);
+    unboxed coord (point);
 
     record payload (
         coord location,
@@ -131,14 +131,14 @@ It's represented in JSON as:
 
 The internal type also can be a option/set/list/map type:
 
-    boxed box-option (text?);
+    unboxed box-option (text?);
 
     enum color = red | green | blue;
-    boxed box-set ({color});
+    unboxed box-set ({color});
 
-    boxed box-list ([float64]);
+    unboxed box-list ([float64]);
 
-    boxed box-map ({uuid: datetime});
+    unboxed box-map ({uuid: datetime});
 
     record payload (
         box-option a,

--- a/examples/shapes.nrm
+++ b/examples/shapes.nrm
@@ -1,11 +1,11 @@
 # Module consists zero or more type declarations.
 
-boxed offset (float64);
-# The key difference between boxed type and reocrd type consisting of a single
+unboxed offset (float64);
+# The key difference between unboxed type and reocrd type consisting of a single
 # field is that the former has the same JSON representation to its target type,
 # while the latter has thicker JSON representation than its only field.
 #
-# For example, a value of `boxed offset (float);` type is represented
+# For example, a value of `unboxed offset (float);` type is represented
 # in JSON as:
 #
 #     120.5

--- a/src/Nirum/Constructs/Identifier.hs
+++ b/src/Nirum/Constructs/Identifier.hs
@@ -52,12 +52,12 @@ import Nirum.Constructs (Construct(toCode))
 data Identifier = Identifier T.Text deriving (Show)
 
 reservedKeywords :: S.Set Identifier
-reservedKeywords = [ "boxed"
-                   , "enum"
+reservedKeywords = [ "enum"
                    , "record"
                    , "service"
                    , "throws"
                    , "type"
+                   , "unboxed"
                    , "union"
                    ]
 

--- a/src/Nirum/Constructs/TypeDeclaration.hs
+++ b/src/Nirum/Constructs/TypeDeclaration.hs
@@ -47,7 +47,7 @@ import Nirum.Constructs.TypeExpression (TypeExpression)
 
 data Type
     = Alias { canonicalType :: TypeExpression }
-    | BoxedType { innerType :: TypeExpression }
+    | UnboxedType { innerType :: TypeExpression }
     | EnumType { members :: DeclarationSet EnumMember }
     | RecordType { fields :: DeclarationSet Field }
     | UnionType { tags :: DeclarationSet Tag }
@@ -143,9 +143,9 @@ instance Construct TypeDeclaration where
                  , " = ", toCode cname, ";"
                  , toCodeWithPrefix "\n" (A.lookupDocs annotationSet')
                  ]
-    toCode (TypeDeclaration name' (BoxedType itype) annotationSet') =
+    toCode (TypeDeclaration name' (UnboxedType itype) annotationSet') =
         T.concat [ toCode annotationSet'
-                 , "boxed ", toCode name'
+                 , "unboxed ", toCode name'
                  , " (", toCode itype, ");"
                  , toCodeWithPrefix "\n" (A.lookupDocs annotationSet')]
     toCode (TypeDeclaration name' (EnumType members') annotationSet') =

--- a/test/Nirum/Constructs/ModuleSpec.hs
+++ b/test/Nirum/Constructs/ModuleSpec.hs
@@ -20,7 +20,7 @@ spec =
         let docsAnno = A.docs "path string"
             pathT = TypeDeclaration "path" (Alias "text") (singleton docsAnno)
             offsetT =
-                TypeDeclaration "offset" (BoxedType "float64") empty
+                TypeDeclaration "offset" (UnboxedType "float64") empty
             decls = [ Import ["foo", "bar"] "baz" empty
                     , Import ["foo", "bar"] "qux" empty
                     , Import ["zzz"] "qqq" empty
@@ -45,7 +45,7 @@ import zzz (ppp, qqq);
 type path = text;
 # path string
 
-boxed offset (float64);
+unboxed offset (float64);
 |]
             toCode mod2 `shouldBe` [q|# module level docs...
 # blahblah
@@ -56,5 +56,5 @@ import zzz (ppp, qqq);
 type path = text;
 # path string
 
-boxed offset (float64);
+unboxed offset (float64);
 |]

--- a/test/Nirum/Constructs/TypeDeclarationSpec.hs
+++ b/test/Nirum/Constructs/TypeDeclarationSpec.hs
@@ -46,10 +46,10 @@ spec = do
             specify "toCode" $ do
                 toCode a `shouldBe` "type path = text;"
                 toCode b `shouldBe` "type path = text;\n# docs"
-        context "BoxedType" $ do
-            let boxed = BoxedType "float64"
+        context "UnboxedType" $ do
+            let unboxed = UnboxedType "float64"
                 a = TypeDeclaration { typename = "offset"
-                                    , type' = boxed
+                                    , type' = unboxed
                                     , typeAnnotations = empty
                                     }
                 b = a { typeAnnotations = singleDocs "docs" }
@@ -60,8 +60,8 @@ spec = do
                 docs a `shouldBe` Nothing
                 docs b `shouldBe` Just "docs"
             specify "toCode" $ do
-                toCode a `shouldBe` "boxed offset (float64);"
-                toCode b `shouldBe` "boxed offset (float64);\n# docs"
+                toCode a `shouldBe` "unboxed offset (float64);"
+                toCode b `shouldBe` "unboxed offset (float64);\n# docs"
         context "EnumType" $ do
             let enumMembers = [ EnumMember "kr" empty
                               , EnumMember "jp" (singleDocs "Japan")


### PR DESCRIPTION
Fixes #65 and depends on spoqa/nirum-python#41.  (So the builds will be broken until spoqa/nirum-python#41 gets merged.)

Renamed `boxed` keyword to `unboxed` as I suggested from #65.  Also adjusted docs and examples.