### PR TITLE
Lint using Haskell style scanner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,10 @@ install:
 - 'sed -E "s/resolver\s*:\s*.*/resolver: $RESOLVER/" stack.yaml > stack-new.yaml'
 - mv stack-new.yaml stack.yaml
 - travis_long stack --no-terminal setup
+- travis_long stack --no-terminal install scan
 script:
 - source "$HOME/.pyvenv/bin/activate" && stack --no-terminal test
+- ./lint.sh
 before_deploy:
 - stack build --no-terminal --copy-bins
 - mkdir -p /tmp/nirum-build

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Building
 If you already installed [Haskell Platform][5] or [Haskell Stack][6],
 you can build the project in the same way to build other Haskell projects.
 
-Using Stack:
+Using Haskell Stack:
 
     $ stack build
 
@@ -82,6 +82,12 @@ Using vanilla Cabal:
     $ cabal install --only-dependencies
     $ cabal configure
     $ cabal build
+
+You can run the test suite of Nirum:
+
+    $ stack test  # using Hasekll Stack
+    $ cabal test  # using Haskell Platform
+    $ ./lint.sh   # run style lint as well
 
 [5]: https://www.haskell.org/platform/
 [6]: https://www.haskellstack.org/

--- a/lint.sh
+++ b/lint.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -e
+
+function abspath {
+  cd "$1"
+  pwd
+}
+
+# Automatically install this script as a pre-commit hook
+if [[ -d .git/ && ! -f .git/hooks/pre-commit ]]; then
+  mkdir -p .git/hooks/
+  cat <<EOF > .git/hooks/pre-commit
+#!/usr/bin/env bash
+set -e
+$(abspath "$(dirname "$0")")/lint.sh
+EOF
+  chmod +x .git/hooks/pre-commit
+fi
+
+if [[ "$(which stack)" != "" ]] && stack --help | head -n1 | grep -qi haskell
+then
+  stack test hlint
+  if [[ "$(stack exec scan -- -v)" = "" ]]; then
+    stack install scan
+  fi
+  scan=(stack exec scan --)
+else
+  cabal test hlint
+  cabal install scan
+  scan=(scan)
+fi
+
+# Haskell style scanner doesn't provide proper exit code ---
+# it always exists with zero even if it found errors.
+scanout="$(mktemp)"
+find src test -name '*.hs' -print0 | \
+    xargs -0 "${scan[@]}" -j false -c false > "$scanout"
+cat "$scanout"
+if [[ "$(cat "$scanout")" != "" ]]; then
+  exit 1
+fi

--- a/nirum.cabal
+++ b/nirum.cabal
@@ -125,6 +125,7 @@ test-suite spec
                ,       process                  >=1.1     && <2
                ,       semigroups
                ,       semver                   >=0.3.0   && <1.0
+               ,       string-qq                >=0.0.2   && <0.1.0
                ,       temporary                >=1.2     && <1.3
                ,       text                     >=0.9.1.0 && <1.3
   ghc-options:         -Wall -Werror

--- a/src/Nirum/Cli.hs
+++ b/src/Nirum/Cli.hs
@@ -2,7 +2,7 @@
 module Nirum.Cli (main, writeFiles) where
 
 import Control.Monad (forM_)
-import GHC.Exts (IsList(toList))
+import GHC.Exts (IsList (toList))
 import System.IO.Error (catchIOError, ioeGetErrorString)
 
 import qualified Data.Map.Strict as M
@@ -27,12 +27,12 @@ import System.FilePath (takeDirectory, (</>))
 import Text.InterpolatedString.Perl6 (qq)
 import Text.Megaparsec (Token)
 import Text.Megaparsec.Error ( Dec
-                             , ParseError(errorPos)
+                             , ParseError (errorPos)
                              , parseErrorPretty
                              )
-import Text.Megaparsec.Pos (SourcePos(sourceLine, sourceColumn), unPos)
+import Text.Megaparsec.Pos (SourcePos (sourceLine, sourceColumn), unPos)
 
-import Nirum.Constructs (Construct(toCode))
+import Nirum.Constructs (Construct (toCode))
 import Nirum.Constructs.Identifier (toText)
 import Nirum.Constructs.ModulePath (ModulePath)
 import Nirum.Package ( PackageError ( ImportError
@@ -136,8 +136,8 @@ main' = do
     scanResult <- scanPackage src
     case scanResult of
         Left (ParseError modulePath error') -> do
-            -- FIXME: find more efficient way to determine filename from
-            --        the given module path
+            {- FIXME: find more efficient way to determine filename from
+                      the given module path -}
             filePaths <- scanModules src
             case M.lookup modulePath filePaths of
                 Just filePath' -> do
@@ -154,7 +154,7 @@ main' = do
 
 writeFiles :: FilePath -> M.Map FilePath (Either T.Text T.Text) -> IO ()
 writeFiles obj m =
-    forM_ files $ \(filePath, result) ->
+    forM_ files $ \ (filePath, result) ->
         case result of
             Left compileError -> putStrLn [qq|error: $filePath: $compileError|]
             Right code -> do

--- a/src/Nirum/CodeGen.hs
+++ b/src/Nirum/CodeGen.hs
@@ -7,7 +7,11 @@ module Nirum.CodeGen ( CodeGen
 
 import Control.Applicative (Applicative)
 import Control.Monad (Monad)
-import Control.Monad.Except (MonadError, ExceptT(ExceptT), mapExceptT, runExceptT)
+import Control.Monad.Except ( MonadError
+                            , ExceptT (ExceptT)
+                            , mapExceptT
+                            , runExceptT
+                            )
 import Control.Monad.State (MonadState, State, mapState, runState)
 import Data.Functor (Functor)
 
@@ -33,7 +37,7 @@ instance (Failure s e) => Monad (CodeGen s e) where
     {-# INLINE (>>=) #-}
     fail str = CodeGen $ mapExceptT mutate (fromString str)
       where
-        mutate = mapState (\(a, s) -> case a of
+        mutate = mapState (\ (a, s) -> case a of
                                           Left _ -> undefined
                                           Right e -> (Left e, s))
     {-# INLINE fail #-}

--- a/src/Nirum/Constructs/Annotation.hs
+++ b/src/Nirum/Constructs/Annotation.hs
@@ -1,7 +1,7 @@
-module Nirum.Constructs.Annotation ( Annotation(Annotation)
+module Nirum.Constructs.Annotation ( Annotation (Annotation)
                                    , AnnotationSet
                                    , Metadata
-                                   , NameDuplication(AnnotationNameDuplication)
+                                   , NameDuplication (AnnotationNameDuplication)
                                    , annotations
                                    , docs
                                    , empty
@@ -53,9 +53,9 @@ fromList annotations' =
     findDup :: [Identifier] -> S.Set Identifier -> Maybe Identifier
     findDup identifiers dups =
         case identifiers of
-            x:xs -> if x `S.member` dups
-                    then Just x
-                    else findDup xs $ S.insert x dups
+            x : xs -> if x `S.member` dups
+                      then Just x
+                      else findDup xs $ S.insert x dups
             _ -> Nothing
 
 toList :: AnnotationSet -> [Annotation]
@@ -79,8 +79,8 @@ lookupDocs annotationSet = do
 insertDocs :: (Monad m) => Docs -> AnnotationSet -> m AnnotationSet
 insertDocs docs' (AnnotationSet anno) =
     case insertLookup annotationDocsName (Just $ toText docs') anno of
-        (Just _ , _    ) -> fail "<duplicated>"
+        (Just _ , _) -> fail "<duplicated>"
         (Nothing, anno') -> return $ AnnotationSet anno'
   where
     insertLookup :: Ord k => k -> a -> M.Map k a -> (Maybe a, M.Map k a)
-    insertLookup = M.insertLookupWithKey (\_ a _ -> a)
+    insertLookup = M.insertLookupWithKey $ \ _ a _ -> a

--- a/src/Nirum/Constructs/Annotation/Internal.hs
+++ b/src/Nirum/Constructs/Annotation/Internal.hs
@@ -1,6 +1,11 @@
 {-# LANGUAGE QuasiQuotes #-}
-module Nirum.Constructs.Annotation.Internal ( Annotation(..)
-                                            , AnnotationSet(..)
+module Nirum.Constructs.Annotation.Internal ( Annotation ( Annotation
+                                                         , metadata
+                                                         , name
+                                                         )
+                                            , AnnotationSet ( AnnotationSet
+                                                            , annotations
+                                                            )
                                             , Metadata
                                             , fromTuple
                                             ) where
@@ -23,15 +28,16 @@ data Annotation = Annotation { name :: Identifier
                              } deriving (Eq, Ord, Show)
 
 instance Construct Annotation where
-    toCode Annotation {name = n,  metadata = Just m} = [qq|@{toCode n}("$m'")|]
+    toCode Annotation {name = n, metadata = Just m} =
+        [qq|@{toCode n}("$m'")|]
       where
         m' = (showLitString $ T.unpack m) ""
         showLitString :: String -> ShowS
         showLitString = foldr ((.) . showLitChar') id
         showLitChar' :: Char -> ShowS
         showLitChar' '"' = showString "\\\""
-        showLitChar' c   = C.showLitChar c
-    toCode Annotation {name = n,  metadata = Nothing} = [qq|@{toCode n}|]
+        showLitChar' c = C.showLitChar c
+    toCode Annotation {name = n, metadata = Nothing} = [qq|@{toCode n}|]
 
 fromTuple :: (Identifier, Maybe Metadata) -> Annotation
 fromTuple (name', meta') = Annotation { name = name', metadata = meta' }

--- a/src/Nirum/Constructs/Declaration.hs
+++ b/src/Nirum/Constructs/Declaration.hs
@@ -11,7 +11,7 @@ import Nirum.Constructs.Name (Name)
 
 -- 'Construct' which has its own unique 'name' and can has its 'docs'.
 class Construct a => Declaration a where
-    name        :: a -> Name
+    name :: a -> Name
     annotations :: a -> AnnotationSet
 
 docs :: Declaration a => a -> Maybe Docs

--- a/src/Nirum/Constructs/DeclarationSet.hs
+++ b/src/Nirum/Constructs/DeclarationSet.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE OverloadedLists, TypeFamilies #-}
-module Nirum.Constructs.DeclarationSet ( DeclarationSet()
-                                       , NameDuplication( BehindNameDuplication
-                                                        , FacialNameDuplication
-                                                        )
+module Nirum.Constructs.DeclarationSet ( DeclarationSet ()
+                                       , NameDuplication ( BehindNameDuplication
+                                                         , FacialNameDuplication
+                                                         )
                                        , empty
                                        , fromList
                                        , lookup
@@ -22,9 +22,9 @@ import Prelude hiding (lookup, null)
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 
-import Nirum.Constructs.Declaration (Declaration(name))
+import Nirum.Constructs.Declaration (Declaration (name))
 import Nirum.Constructs.Identifier (Identifier)
-import Nirum.Constructs.Name (Name(Name, behindName, facialName))
+import Nirum.Constructs.Name (Name (Name, behindName, facialName))
 
 data Declaration a => DeclarationSet a
     -- | The set of 'Declaration' values.
@@ -62,10 +62,10 @@ fromList declarations' =
     findDup :: [Name] -> (Name -> Identifier) -> S.Set Identifier -> Maybe Name
     findDup names' f dups =
         case names' of
-            x:xs -> let name' = f x
-                    in if name' `S.member` dups
-                       then Just x
-                       else findDup xs f $ S.insert name' dups
+            x : xs -> let name' = f x
+                      in if name' `S.member` dups
+                         then Just x
+                         else findDup xs f $ S.insert name' dups
             _ -> Nothing
 
 toList :: Declaration a => DeclarationSet a -> [a]

--- a/src/Nirum/Constructs/Docs.hs
+++ b/src/Nirum/Constructs/Docs.hs
@@ -1,16 +1,16 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Nirum.Constructs.Docs ( Docs(Docs)
+module Nirum.Constructs.Docs ( Docs (Docs)
                              , annotationDocsName
                              , toCode
                              , toCodeWithPrefix
                              , toText
                              ) where
 
-import Data.String (IsString(fromString))
+import Data.String (IsString (fromString))
 
 import qualified Data.Text as T
 
-import Nirum.Constructs (Construct(toCode))
+import Nirum.Constructs (Construct (toCode))
 import Nirum.Constructs.Identifier (Identifier)
 
 annotationDocsName :: Identifier
@@ -26,8 +26,8 @@ toText (Docs docs') = docs'
 -- | Similar to 'toCode' except it takes 'Maybe Docs' instead of 'Docs'.
 -- If the given docs is 'Nothing' it simply returns an empty string.
 -- Otherwise it returns a code string with the prefix.
-toCodeWithPrefix :: T.Text     -- | The prefix to be prepended if not empty.
-                 -> Maybe Docs -- | The docs to convert to code.
+toCodeWithPrefix :: T.Text     -- ^ The prefix to be prepended if not empty.
+                 -> Maybe Docs -- ^ The docs to convert to code.
                  -> T.Text
 toCodeWithPrefix _ Nothing = ""
 toCodeWithPrefix prefix (Just docs') = T.append prefix $ toCode docs'

--- a/src/Nirum/Constructs/Identifier.hs
+++ b/src/Nirum/Constructs/Identifier.hs
@@ -21,7 +21,7 @@ module Nirum.Constructs.Identifier ( Identifier
 
 import Data.Char (toLower, toUpper)
 import Data.Maybe (fromMaybe)
-import Data.String (IsString(fromString))
+import Data.String (IsString (fromString))
 
 import qualified Data.Text as T
 import qualified Data.Set as S
@@ -29,26 +29,28 @@ import qualified Text.Megaparsec as P
 import Text.Megaparsec.Char (oneOf, satisfy)
 import Text.Megaparsec.Text (Parser)
 
-import Nirum.Constructs (Construct(toCode))
+import Nirum.Constructs (Construct (toCode))
 
--- | Case-insensitive identifier.  It also doesn't distinguish hyphens
--- from underscores.
---
--- It has more restrict rules than the most of programming languages:
---
--- * It can't start with digits or hyphens/underscores.
--- * Hyphens/underscores can't continuously appear more than once.
--- * Only roman alphabets, Arabic numerals, hyphens and underscores
---   are allowed.
--- 
--- These rules are for portability between various programming languages.
--- For example, @BOOK_CATEGORY@ and @Book-Category@ are all normalized
--- to @book-category@, and it can be translated to:
--- 
--- [snake_case] @book_category@
--- [camelCase] @bookCategory@
--- [PascalCase] @BookCategory@
--- [lisp-case] @book-category@
+{- |
+Case-insensitive identifier.  It also doesn't distinguish hyphens
+from underscores.
+
+It has more restrict rules than the most of programming languages:
+
+* It can't start with digits or hyphens/underscores.
+* Hyphens/underscores can't continuously appear more than once.
+* Only roman alphabets, Arabic numerals, hyphens and underscores
+  are allowed.
+
+These rules are for portability between various programming languages.
+For example, @BOOK_CATEGORY@ and @Book-Category@ are all normalized
+to @book-category@, and it can be translated to:
+
+[snake_case] @book_category@
+[camelCase] @bookCategory@
+[PascalCase] @BookCategory@
+[lisp-case] @book-category@
+-}
 data Identifier = Identifier T.Text deriving (Show)
 
 reservedKeywords :: S.Set Identifier
@@ -68,7 +70,7 @@ identifierRule = do
     restWords <- P.many $ do
         sep <- oneOf ("-_" :: String)
         chars <- P.some $ satisfy isAlnum
-        return $ T.pack $ sep:chars
+        return $ T.pack $ sep : chars
     return $ Identifier $ T.concat $ T.pack (firstChar : restChars) : restWords
   where
     isAlpha :: Char -> Bool
@@ -78,7 +80,7 @@ identifierRule = do
     isAlnum :: Char -> Bool
     isAlnum c = isAlpha c || isDigit c
 
--- | Constructs a 'Identifier' value from the given identifier string.
+-- | Constructs an 'Identifier' value from the given identifier string.
 -- It could return 'Nothing' if the given identifier is invalid.
 fromText :: T.Text -> Maybe Identifier
 fromText text =
@@ -94,7 +96,7 @@ fromText text =
 
 normalize :: Identifier -> Identifier
 normalize (Identifier i) =
-    Identifier $ T.map (\c -> if c == '_' then '-' else toLower c) i
+    Identifier $ T.map (\ c -> if c == '_' then '-' else toLower c) i
 
 toText :: Identifier -> T.Text
 toText (Identifier text) = text

--- a/src/Nirum/Constructs/Module.hs
+++ b/src/Nirum/Constructs/Module.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE OverloadedLists, QuasiQuotes  #-}
-module Nirum.Constructs.Module ( Module(Module, docs, types)
+{-# LANGUAGE OverloadedLists, QuasiQuotes #-}
+module Nirum.Constructs.Module ( Module (Module, docs, types)
                                , coreModule
                                , coreModulePath
                                , coreTypes
@@ -11,16 +11,34 @@ import qualified Data.Set as S
 import qualified Data.Text as T
 import Text.InterpolatedString.Perl6 (q)
 
-import Nirum.Constructs (Construct(toCode))
+import Nirum.Constructs (Construct (toCode))
 import Nirum.Constructs.Annotation (empty)
 import Nirum.Constructs.Docs (Docs)
 import qualified Nirum.Constructs.DeclarationSet as DS
 import Nirum.Constructs.Identifier (Identifier)
 import Nirum.Constructs.ModulePath (ModulePath)
-import Nirum.Constructs.TypeDeclaration ( JsonType(..)
-                                        , PrimitiveTypeIdentifier(..)
-                                        , Type(..)
-                                        , TypeDeclaration(..)
+import Nirum.Constructs.TypeDeclaration ( JsonType (Boolean, Number, String)
+                                        , PrimitiveTypeIdentifier ( Bigint
+                                                                  , Binary
+                                                                  , Bool
+                                                                  , Date
+                                                                  , Datetime
+                                                                  , Decimal
+                                                                  , Float32
+                                                                  , Float64
+                                                                  , Int32
+                                                                  , Int64
+                                                                  , Text
+                                                                  , Uri
+                                                                  , Uuid
+                                                                  )
+                                        , Type (PrimitiveType)
+                                        , TypeDeclaration ( Import
+                                                          , TypeDeclaration
+                                                          , type'
+                                                          , typeAnnotations
+                                                          , typename
+                                                          )
                                         )
 
 data Module = Module { types :: DS.DeclarationSet TypeDeclaration

--- a/src/Nirum/Constructs/ModulePath.hs
+++ b/src/Nirum/Constructs/ModulePath.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE TypeFamilies #-}
-module Nirum.Constructs.ModulePath ( ModulePath( ModuleName
-                                               , ModulePath
-                                               , moduleName
-                                               , path
-                                               )
+module Nirum.Constructs.ModulePath ( ModulePath ( ModuleName
+                                                , ModulePath
+                                                , moduleName
+                                                , path
+                                                )
                                    , ancestors
                                    , fromFilePath
                                    , fromIdentifiers
@@ -11,17 +11,18 @@ module Nirum.Constructs.ModulePath ( ModulePath( ModuleName
 
 import Data.Char (toLower)
 import Data.Maybe (fromMaybe, mapMaybe)
-import GHC.Exts (IsList(Item, fromList, toList))
+import GHC.Exts (IsList (Item, fromList, toList))
 
 import Data.Set (Set, insert, singleton)
 import Data.Text (intercalate, pack)
 import System.FilePath (splitDirectories, stripExtension)
 
-import Nirum.Constructs (Construct(toCode))
+import Nirum.Constructs (Construct (toCode))
 import Nirum.Constructs.Identifier (Identifier, fromText)
 
 data ModulePath = ModulePath { path :: ModulePath
-                             , moduleName :: Identifier }
+                             , moduleName :: Identifier
+                             }
                 | ModuleName { moduleName :: Identifier }
                 deriving (Eq, Show)
 
@@ -61,7 +62,7 @@ ancestors m@(ModulePath parent _) = m `insert` ancestors parent
 instance IsList ModulePath where
     type Item ModulePath = Identifier
     fromList identifiers =
-        fromMaybe (error "ModulePath cannot be empty") 
+        fromMaybe (error "ModulePath cannot be empty")
                   (fromIdentifiers identifiers)
     toList (ModuleName identifier) = [identifier]
     toList (ModulePath path' identifier) = toList path' ++ [identifier]

--- a/src/Nirum/Constructs/Name.hs
+++ b/src/Nirum/Constructs/Name.hs
@@ -1,25 +1,25 @@
-module Nirum.Constructs.Name ( Name(Name)
-                             , behindName
-                             , facialName
+module Nirum.Constructs.Name ( Name (Name, behindName, facialName)
                              , isComplex
                              , isSimple
                              , toCode
                              ) where
 
-import Data.String (IsString(fromString))
+import Data.String (IsString (fromString))
 
 import Data.Text (append, snoc)
 
 import Nirum.Constructs (Construct)
 import Nirum.Constructs.Identifier (Identifier, toCode)
 
--- | Name consists of a 'facialName' and a 'behindName'.
--- The 'behindName' is for internal coding, while the 'facialName' is for
--- human-readable identifier of programming language bindings.
---
--- If 'behind_Name' is omitted, 'facialName' is used also for
--- 'behindName'.  Explicit 'behindName' is useful to maintain
--- old name for backward compatibility with new 'facialName'.
+{- |
+Name consists of a 'facialName' and a 'behindName'.
+The 'behindName' is for internal coding, while the 'facialName' is for
+human-readable identifier of programming language bindings.
+
+If 'behind_Name' is omitted, 'facialName' is used also for
+'behindName'.  Explicit 'behindName' is useful to maintain
+old name for backward compatibility with new 'facialName'.
+-}
 data Name = Name { facialName :: Identifier
                  , behindName :: Identifier
                  } deriving (Eq, Ord, Show)

--- a/src/Nirum/Constructs/Service.hs
+++ b/src/Nirum/Constructs/Service.hs
@@ -4,16 +4,16 @@ module Nirum.Constructs.Service ( Method ( Method
                                          , parameters
                                          , returnType
                                          )
-                                , Parameter(Parameter)
-                                , Service(Service, methods)
+                                , Parameter (Parameter)
+                                , Service (Service, methods)
                                 , methodDocs
                                 ) where
 
 import qualified Data.Text as T
 
-import Nirum.Constructs (Construct(toCode))
+import Nirum.Constructs (Construct (toCode))
 import Nirum.Constructs.Annotation (AnnotationSet, empty, lookupDocs)
-import Nirum.Constructs.Declaration (Declaration(annotations, name), docs)
+import Nirum.Constructs.Declaration (Declaration (annotations, name), docs)
 import Nirum.Constructs.Docs (Docs, toCodeWithPrefix)
 import Nirum.Constructs.DeclarationSet (DeclarationSet, toList)
 import Nirum.Constructs.Name (Name)
@@ -40,7 +40,7 @@ instance Declaration Parameter where
 data Method = Method { methodName :: Name
                      , parameters :: DeclarationSet Parameter
                      , returnType :: TypeExpression
-                     , errorType  :: Maybe TypeExpression
+                     , errorType :: Maybe TypeExpression
                      , methodAnnotations :: AnnotationSet
                      } deriving (Eq, Ord, Show)
 

--- a/src/Nirum/Constructs/TypeDeclaration.hs
+++ b/src/Nirum/Constructs/TypeDeclaration.hs
@@ -1,44 +1,73 @@
-module Nirum.Constructs.TypeDeclaration ( EnumMember(EnumMember)
+module Nirum.Constructs.TypeDeclaration ( EnumMember (EnumMember)
                                         , Field ( Field
                                                 , fieldAnnotations
                                                 , fieldName
                                                 , fieldType
                                                 )
-                                        , JsonType(..)
-                                        , PrimitiveTypeIdentifier(..)
+                                        , JsonType ( Boolean
+                                                   , Number
+                                                   , String
+                                                   )
+                                        , PrimitiveTypeIdentifier ( Bigint
+                                                                  , Binary
+                                                                  , Bool
+                                                                  , Date
+                                                                  , Datetime
+                                                                  , Decimal
+                                                                  , Float32
+                                                                  , Float64
+                                                                  , Int32
+                                                                  , Int64
+                                                                  , Text
+                                                                  , Uri
+                                                                  , Uuid
+                                                                  )
                                         , Tag ( Tag
                                               , tagAnnotations
                                               , tagFields
                                               , tagName
                                               )
-                                        , Type(..)
-                                        , TypeDeclaration( Import
-                                                         , ServiceDeclaration
-                                                         , TypeDeclaration
-                                                         , importName
-                                                         , modulePath
-                                                         , service
-                                                         , serviceAnnotations
-                                                         , serviceName
-                                                         , type'
-                                                         , typeAnnotations
-                                                         , typename
-                                                         )
+                                        , Type ( Alias
+                                               , EnumType
+                                               , PrimitiveType
+                                               , RecordType
+                                               , UnboxedType
+                                               , UnionType
+                                               , canonicalType
+                                               , fields
+                                               , innerType
+                                               , jsonType
+                                               , members
+                                               , primitiveTypeIdentifier
+                                               , tags
+                                               )
+                                        , TypeDeclaration ( Import
+                                                          , ServiceDeclaration
+                                                          , TypeDeclaration
+                                                          , importName
+                                                          , modulePath
+                                                          , service
+                                                          , serviceAnnotations
+                                                          , serviceName
+                                                          , type'
+                                                          , typeAnnotations
+                                                          , typename
+                                                          )
                                         ) where
 
 import Data.Maybe (isJust)
-import Data.String (IsString(fromString))
+import Data.String (IsString (fromString))
 
 import qualified Data.Text as T
 
-import Nirum.Constructs (Construct(toCode))
+import Nirum.Constructs (Construct (toCode))
 import Nirum.Constructs.Annotation as A (AnnotationSet, empty, lookupDocs)
-import Nirum.Constructs.Declaration (Declaration(..), docs)
-import Nirum.Constructs.Docs (Docs(..), toCodeWithPrefix)
+import Nirum.Constructs.Declaration (Declaration (annotations, name), docs)
+import Nirum.Constructs.Docs (Docs (Docs), toCodeWithPrefix)
 import Nirum.Constructs.DeclarationSet (DeclarationSet, null', toList)
 import Nirum.Constructs.Identifier (Identifier)
 import Nirum.Constructs.ModulePath (ModulePath)
-import Nirum.Constructs.Name (Name(Name))
+import Nirum.Constructs.Name (Name (Name))
 import Nirum.Constructs.Service ( Method
                                 , Service (Service)
                                 , methodDocs

--- a/src/Nirum/Constructs/TypeExpression.hs
+++ b/src/Nirum/Constructs/TypeExpression.hs
@@ -12,11 +12,11 @@ module Nirum.Constructs.TypeExpression ( TypeExpression ( ListModifier
                                        , toCode
                                        ) where
 
-import Data.String (IsString(fromString))
+import Data.String (IsString (fromString))
 
 import qualified Data.Text as T
 
-import Nirum.Constructs (Construct(toCode))
+import Nirum.Constructs (Construct (toCode))
 import Nirum.Constructs.Identifier (Identifier)
 
 -- | Refers a type.

--- a/src/Nirum/Package.hs
+++ b/src/Nirum/Package.hs
@@ -1,4 +1,4 @@
-module Nirum.Package ( BoundModule(boundPackage, modulePath)
+module Nirum.Package ( BoundModule (boundPackage, modulePath)
                      , Package (Package, metadata, modules)
                      , PackageError ( ImportError
                                     , MetadataError
@@ -19,7 +19,7 @@ module Nirum.Package ( BoundModule(boundPackage, modulePath)
 import System.IO.Error (catchIOError)
 
 import Control.Monad.Except ( ExceptT
-                            , MonadError(throwError)
+                            , MonadError (throwError)
                             , liftIO
                             , runExceptT
                             )
@@ -43,7 +43,7 @@ import Nirum.Constructs.TypeDeclaration ( Type
 import Nirum.Package.Metadata ( Metadata
                               , MetadataError
                               , metadataPath
-                              , readFromPackage 
+                              , readFromPackage
                               )
 import qualified Nirum.Package.ModuleSet as MS
 import Nirum.Parser (ParseError, parseFile)
@@ -77,7 +77,7 @@ scanPackage packagePath = runExceptT $ do
         Right m -> return m
         Left e -> throwError $ MetadataError e
     modulePaths <- liftIO $ scanModules packagePath
-    modules' <- mapM (\p -> catch (parseFile p) $ ScanError p) modulePaths
+    modules' <- mapM (\ p -> catch (parseFile p) $ ScanError p) modulePaths
     case M.foldrWithKey excludeFailedParse (Right M.empty) modules' of
         Right parsedModules -> case MS.fromMap parsedModules of
             Right ms -> return $ Package metadata' ms
@@ -108,7 +108,7 @@ scanModules packagePath = do
     return $ M.fromList files
   where
     isNotHidden :: FilePath -> Bool
-    isNotHidden ('.':_) = False
+    isNotHidden ('.' : _) = False
     isNotHidden _ = True
     scanFiles :: FilePath -> IO [(ModulePath, FilePath)]
     scanFiles path = do

--- a/src/Nirum/Package/Metadata.hs
+++ b/src/Nirum/Package/Metadata.hs
@@ -11,7 +11,7 @@ module Nirum.Package.Metadata ( Author (Author, email, name, uri)
                               , metadataFilename
                               , metadataPath
                               , parseMetadata
-                              , readFromPackage 
+                              , readFromPackage
                               , readMetadata
                               ) where
 
@@ -131,9 +131,9 @@ optional (Left (FieldError _)) = Right Nothing
 optional (Left error') = Left error'
 
 stringField :: MetadataField -> Table -> Either MetadataError Text
-stringField = typedField "string" $ \n -> case n of
-                                               VString s -> Just s
-                                               _ -> Nothing
+stringField = typedField "string" $ \ n -> case n of
+                                                VString s -> Just s
+                                                _ -> Nothing
 
 tableArrayField :: MetadataField -> Table -> Either MetadataError VTArray
 tableArrayField f t =
@@ -143,7 +143,7 @@ tableArrayField f t =
         Left error' -> Left error'
   where
     arrayF :: MetadataField -> Table -> Either MetadataError VTArray
-    arrayF = typedField "array of tables" $ \node ->
+    arrayF = typedField "array of tables" $ \ node ->
         case node of
             VTArray array -> Just array
             _ -> Nothing

--- a/src/Nirum/Package/ModuleSet.hs
+++ b/src/Nirum/Package/ModuleSet.hs
@@ -118,4 +118,3 @@ detectCircularImports (ModuleSet ms) =
       where
         reversedCycle' :: [ModulePath]
         reversedCycle' = path : reversedCycle
-

--- a/src/Nirum/Parser.hs
+++ b/src/Nirum/Parser.hs
@@ -70,11 +70,11 @@ import Text.Megaparsec.Lexer (charLiteral)
 
 import qualified Nirum.Constructs.Annotation as A
 import Nirum.Constructs.Declaration (Declaration)
-import Nirum.Constructs.Docs (Docs(Docs))
+import Nirum.Constructs.Docs (Docs (Docs))
 import Nirum.Constructs.DeclarationSet ( DeclarationSet
-                                       , NameDuplication( BehindNameDuplication
-                                                        , FacialNameDuplication
-                                                        )
+                                       , NameDuplication ( BehindNameDuplication
+                                                         , FacialNameDuplication
+                                                         )
                                        , empty
                                        , fromList
                                        )
@@ -83,35 +83,35 @@ import Nirum.Constructs.Identifier ( Identifier
                                    , reservedKeywords
                                    , toString
                                    )
-import Nirum.Constructs.Module (Module(Module))
-import Nirum.Constructs.ModulePath (ModulePath(ModulePath, ModuleName))
-import Nirum.Constructs.Name (Name(Name))
-import Nirum.Constructs.Service ( Method(Method)
-                                , Parameter(Parameter)
-                                , Service(Service)
+import Nirum.Constructs.Module (Module (Module))
+import Nirum.Constructs.ModulePath (ModulePath (ModulePath, ModuleName))
+import Nirum.Constructs.Name (Name (Name))
+import Nirum.Constructs.Service ( Method (Method)
+                                , Parameter (Parameter)
+                                , Service (Service)
                                 )
-import Nirum.Constructs.TypeDeclaration ( EnumMember(EnumMember)
-                                        , Field(Field)
-                                        , Tag(Tag)
-                                        , Type( Alias
-                                              , EnumType
-                                              , RecordType
-                                              , UnboxedType
-                                              , UnionType
-                                              )
-                                        , TypeDeclaration( Import
-                                                         , ServiceDeclaration
-                                                         , TypeDeclaration
-                                                         , serviceAnnotations
-                                                         , typeAnnotations
-                                                         )
+import Nirum.Constructs.TypeDeclaration ( EnumMember (EnumMember)
+                                        , Field (Field)
+                                        , Tag (Tag)
+                                        , Type ( Alias
+                                               , EnumType
+                                               , RecordType
+                                               , UnboxedType
+                                               , UnionType
+                                               )
+                                        , TypeDeclaration ( Import
+                                                          , ServiceDeclaration
+                                                          , TypeDeclaration
+                                                          , serviceAnnotations
+                                                          , typeAnnotations
+                                                          )
                                         )
-import Nirum.Constructs.TypeExpression ( TypeExpression( ListModifier
-                                                       , MapModifier
-                                                       , OptionModifier
-                                                       , SetModifier
-                                                       , TypeIdentifier
-                                                       )
+import Nirum.Constructs.TypeExpression ( TypeExpression ( ListModifier
+                                                        , MapModifier
+                                                        , OptionModifier
+                                                        , SetModifier
+                                                        , TypeIdentifier
+                                                        )
                                        )
 
 type ParseError = E.ParseError (Token T.Text) E.Dec
@@ -234,11 +234,12 @@ mapModifier = do
 
 docs :: Parser Docs
 docs = do
-    comments <- sepEndBy1 (do { char '#'
-                              ; void $ optional $ char ' '
-                              ; line <- many $ noneOf ("\r\n" :: String)
-                              ; return $ T.pack line
-                              }) (eol >> spaces) <?> "comments"
+    comments <- sepEndBy1 (do
+            char '#'
+            void $ optional $ char ' '
+            line <- many $ noneOf ("\r\n" :: String)
+            return $ T.pack line
+        ) (eol >> spaces) <?> "comments"
     return $ Docs $ T.unlines comments
 
 annotationsWithDocs :: Monad m
@@ -347,7 +348,7 @@ enumTypeDeclaration = do
             return $ TypeDeclaration typename (EnumType memberSet)
                                      annotationSet''
 
-fieldsOrParameters :: forall a. (String, String)
+fieldsOrParameters :: forall a . (String, String)
                    -> (Name -> TypeExpression -> A.AnnotationSet -> a)
                    -> Parser [a]
 fieldsOrParameters (label, pluralLabel) make = do
@@ -379,7 +380,7 @@ fieldsOrParameters (label, pluralLabel) make = do
         spaces
         return d
     annotationsFromDocs :: Maybe Docs -> A.AnnotationSet
-    annotationsFromDocs Nothing  = A.empty
+    annotationsFromDocs Nothing = A.empty
     annotationsFromDocs (Just d) = A.singleton $ A.docs d
 
 fields :: Parser [Field]
@@ -419,12 +420,12 @@ tag = do
     spaces
     paren <- optional $ char '('
     fields' <- case paren of
-        Just _ -> do { spaces
-                     ; f <- fieldSet <?> "union tag fields"
-                     ; spaces
-                     ; char ')'
-                     ; return f
-                     }
+        Just _ -> do
+            spaces
+            f <- fieldSet <?> "union tag fields"
+            spaces
+            char ')'
+            return f
         Nothing -> return empty
     docs' <- optional $ do
         d <- docs <?> "union tag docs"
@@ -451,7 +452,7 @@ unionTypeDeclaration = do
     spaces
     char ';'
     annotationSet'' <- annotationsWithDocs annotationSet' docs'
-    handleNameDuplication "tag" tags' $ \tagSet ->
+    handleNameDuplication "tag" tags' $ \ tagSet ->
         return $ TypeDeclaration typename (UnionType tagSet) annotationSet''
 
 typeDeclaration :: Parser TypeDeclaration
@@ -479,7 +480,7 @@ typeDeclaration = do
     unless' :: [String] -> Parser a -> Parser a
     unless' [] _ = fail "no candidates"  -- Must never happen
     unless' [s] p = notFollowedBy (string s) >> p
-    unless' (x:xs) p = notFollowedBy (string x) >> unless' xs p
+    unless' (x : xs) p = notFollowedBy (string x) >> unless' xs p
 
 parameters :: Parser [Parameter]
 parameters = fieldsOrParameters ("parameter", "parameters") Parameter
@@ -604,7 +605,7 @@ module' = do
             annotationSet' <- annotationSet <?> "annotations"
             spaces
             decl <- choice [ notFollowedBy (string "service") >> typeDeclaration
-                           , serviceDeclaration <?>  "service declaration"
+                           , serviceDeclaration <?> "service declaration"
                            ]
             -- In theory, though it preconsumes annotationSet' before parsing
             -- decl so that decl itself has no annotations, to prepare for an
@@ -620,7 +621,7 @@ module' = do
         spaces
         return typeDecl
     handleNameDuplication "type" (types ++ [i | l <- importLists, i <- l]) $
-                          \typeSet -> return $ Module typeSet docs'
+                          \ typeSet -> return $ Module typeSet docs'
 
 file :: Parser Module
 file = do
@@ -628,12 +629,12 @@ file = do
     eof
     return mod'
 
-parse :: FilePath -- | Source path (although it's only used for error message)
-      -> T.Text   -- | Input source code
+parse :: FilePath -- ^ Source path (although it's only used for error message)
+      -> T.Text   -- ^ Input source code
       -> Either ParseError Module
 parse = runParser file
 
-parseFile :: FilePath -- | Source path
+parseFile :: FilePath -- ^ Source path
           -> IO (Either ParseError Module)
 parseFile path = do
     code <- readFile path

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -11,10 +11,10 @@ module Nirum.Targets.Python ( Code
                                               , dependencies
                                               , optionalDependencies
                                               )
-                            , Source( Source
-                                    , sourceModule
-                                    , sourcePackage
-                                    )
+                            , Source ( Source
+                                     , sourceModule
+                                     , sourcePackage
+                                     )
                             , addDependency
                             , addOptionalDependency
                             , compileModule
@@ -38,7 +38,7 @@ module Nirum.Targets.Python ( Code
 import Control.Monad.State (modify)
 import qualified Data.List as L
 import Data.Maybe (fromMaybe)
-import GHC.Exts (IsList(toList))
+import GHC.Exts (IsList (toList))
 import Text.Printf (printf)
 
 import qualified Data.Map.Strict as M
@@ -59,39 +59,39 @@ import Nirum.Constructs.Identifier ( Identifier
                                    , toString
                                    )
 import Nirum.Constructs.ModulePath (ModulePath, ancestors)
-import Nirum.Constructs.Name (Name(Name))
+import Nirum.Constructs.Name (Name (Name))
 import qualified Nirum.Constructs.Name as N
-import Nirum.Constructs.Service ( Method( Method
-                                        , methodName
-                                        , parameters
-                                        , returnType
-                                        )
-                                , Parameter(Parameter)
-                                , Service(Service)
+import Nirum.Constructs.Service ( Method ( Method
+                                         , methodName
+                                         , parameters
+                                         , returnType
+                                         )
+                                , Parameter (Parameter)
+                                , Service (Service)
                                 )
-import Nirum.Constructs.TypeDeclaration ( EnumMember(EnumMember)
+import Nirum.Constructs.TypeDeclaration ( EnumMember (EnumMember)
                                         , Field (Field, fieldName)
-                                        , PrimitiveTypeIdentifier(..)
-                                        , Tag(Tag)
-                                        , Type( Alias
-                                              , EnumType
-                                              , PrimitiveType
-                                              , RecordType
-                                              , UnboxedType
-                                              , UnionType
-                                              )
-                                        , TypeDeclaration(..)
+                                        , PrimitiveTypeIdentifier (..)
+                                        , Tag (Tag)
+                                        , Type ( Alias
+                                               , EnumType
+                                               , PrimitiveType
+                                               , RecordType
+                                               , UnboxedType
+                                               , UnionType
+                                               )
+                                        , TypeDeclaration (..)
                                         )
-import Nirum.Constructs.TypeExpression ( TypeExpression( ListModifier
-                                                       , MapModifier
-                                                       , OptionModifier
-                                                       , SetModifier
-                                                       , TypeIdentifier
-                                                       )
+import Nirum.Constructs.TypeExpression ( TypeExpression ( ListModifier
+                                                        , MapModifier
+                                                        , OptionModifier
+                                                        , SetModifier
+                                                        , TypeIdentifier
+                                                        )
                                        )
 import Nirum.Package ( BoundModule
-                     , Package(Package, metadata, modules)
-                     , TypeLookup(Imported, Local, Missing)
+                     , Package (Package, metadata, modules)
+                     , TypeLookup (Imported, Local, Missing)
                      , lookupType
                      , resolveBoundModule
                      , types
@@ -126,7 +126,9 @@ emptyContext = CodeGenContext { standardImports = []
 
 type CodeGen = C.CodeGen CodeGenContext CompileError
 
-runCodeGen :: CodeGen a -> CodeGenContext -> (Either CompileError a, CodeGenContext)
+runCodeGen :: CodeGen a
+           -> CodeGenContext
+           -> (Either CompileError a, CodeGenContext)
 runCodeGen = C.runCodeGen
 
 insertStandardImport :: T.Text -> CodeGen ()
@@ -221,20 +223,20 @@ compileUnionTag source parentname typename' fields = do
         tagNames = map (toAttributeName' . fieldName) (toList fields)
         nameNTypes = zip tagNames typeExprCodes
         slotTypes = toIndentedCodes
-            (\(n, t) -> [qq|'{n}': {t}|]) nameNTypes ",\n        "
+            (\ (n, t) -> [qq|'{n}': {t}|]) nameNTypes ",\n        "
         slots = if length tagNames == 1
                 then [qq|'{head tagNames}'|] `T.snoc` ','
-                else toIndentedCodes (\n -> [qq|'{n}'|]) tagNames ",\n        "
+                else toIndentedCodes (\ n -> [qq|'{n}'|]) tagNames ",\n        "
         hashTuple = if null tagNames
             then "self.__nirum_tag__"
             else [qq|({attributes},)|] :: T.Text
           where
             attributes :: T.Text
-            attributes = toIndentedCodes (\n -> [qq|self.{n}|]) tagNames ", "
+            attributes = toIndentedCodes (\ n -> [qq|self.{n}|]) tagNames ", "
         initialArgs = toIndentedCodes
-            (\(n, t) -> [qq|{n}: {t}|]) nameNTypes ", "
+            (\ (n, t) -> [qq|{n}: {t}|]) nameNTypes ", "
         initialValues =
-            toIndentedCodes (\n -> [qq|self.{n} = {n}|]) tagNames "\n        "
+            toIndentedCodes (\ n -> [qq|self.{n} = {n}|]) tagNames "\n        "
         nameMaps = toIndentedCodes
             toNamePair
             (map fieldName $ toList fields)
@@ -293,8 +295,10 @@ compilePrimitiveType primitiveTypeIdentifier =
         Text -> return "str"
         Binary -> return "bytes"
         Date -> insertStandardImport "datetime" >> return "datetime.date"
-        Datetime -> insertStandardImport "datetime" >> return "datetime.datetime"
-        Uuid -> insertStandardImport "uuid" >> return"uuid.UUID"
+        Datetime -> do
+            insertStandardImport "datetime"
+            return "datetime.datetime"
+        Uuid -> insertStandardImport "uuid" >> return "uuid.UUID"
         Uri -> return "str"
 
 compileTypeExpression :: Source -> TypeExpression -> CodeGen Code
@@ -326,7 +330,7 @@ compileTypeExpression source modifier = do
         MapModifier _ _ -> undefined  -- never happen!
 
 compileTypeDeclaration :: Source -> TypeDeclaration -> CodeGen Code
-compileTypeDeclaration _ TypeDeclaration { type' = PrimitiveType { } } =
+compileTypeDeclaration _ TypeDeclaration { type' = PrimitiveType {} } =
     return ""  -- never used
 compileTypeDeclaration src TypeDeclaration { typename = typename'
                                            , type' = Alias ctype } = do
@@ -409,19 +413,19 @@ compileTypeDeclaration src TypeDeclaration { typename = typename'
                                           ]
         nameNTypes = zip fieldNames typeExprCodes
         slotTypes = toIndentedCodes
-            (\(n, t) -> [qq|'{n}': {t}|]) nameNTypes ",\n        "
-        slots = toIndentedCodes (\n -> [qq|'{n}'|]) fieldNames ",\n        "
+            (\ (n, t) -> [qq|'{n}': {t}|]) nameNTypes ",\n        "
+        slots = toIndentedCodes (\ n -> [qq|'{n}'|]) fieldNames ",\n        "
         initialArgs = toIndentedCodes
-            (\(n, t) -> [qq|{n}: {t}|]) nameNTypes ", "
+            (\ (n, t) -> [qq|{n}: {t}|]) nameNTypes ", "
         initialValues = toIndentedCodes
-            (\n -> [qq|self.{n} = {n}|]) fieldNames "\n        "
+            (\ n -> [qq|self.{n} = {n}|]) fieldNames "\n        "
         nameMaps = toIndentedCodes
             toNamePair
             (map fieldName $ toList fields)
             ",\n        "
         hashTuple = [qq|({attributes},)|] :: T.Text
           where
-            attributes = toIndentedCodes (\n -> [qq|self.{n}|]) fieldNames ","
+            attributes = toIndentedCodes (\ n -> [qq|self.{n}|]) fieldNames ","
     insertStandardImport "typing"
     insertThirdPartyImports [ ("nirum.validate", ["validate_record_type"])
                             , ("nirum.serialize", ["serialize_record_type"])
@@ -476,7 +480,7 @@ compileTypeDeclaration src TypeDeclaration { typename = typename'
     let className = toClassName' typename'
         fieldCodes' = T.intercalate "\n\n" fieldCodes
         enumMembers = toIndentedCodes
-            (\(t, b) -> [qq|$t = '{b}'|]) enumMembers' "\n        "
+            (\ (t, b) -> [qq|$t = '{b}'|]) enumMembers' "\n        "
     insertStandardImport "typing"
     insertStandardImport "enum"
     insertThirdPartyImports [ ("nirum.serialize", ["serialize_union_type"])
@@ -639,7 +643,7 @@ class {className}_Client(client_type, $className):
         )
 |]
 
-compileTypeDeclaration _ Import { } =
+compileTypeDeclaration _ Import {} =
     return ""  -- Nothing to compile
 
 compileModuleBody :: Source -> CodeGen Code
@@ -662,8 +666,8 @@ addDependency requires package =
     requires { dependencies = S.insert package $ dependencies requires }
 
 addOptionalDependency :: InstallRequires
-                      -> (Int, Int)       -- | Python version already stasified
-                      -> T.Text           -- | PyPI package name
+                      -> (Int, Int)       -- ^ Python version already stasified
+                      -> T.Text           -- ^ PyPI package name
                       -> InstallRequires
 addOptionalDependency requires pyVer package =
     requires { optionalDependencies = newOptDeps }
@@ -684,8 +688,8 @@ unionInstallRequires a b =
 compileModule :: Source -> Either CompileError (InstallRequires, Code)
 compileModule source =
     case runCodeGen code' emptyContext of
-        (Left  errMsg, _      ) -> Left errMsg
-        (Right code  , context) -> codeWithDeps context $ [qq|
+        (Left errMsg, _) -> Left errMsg
+        (Right code, context) -> codeWithDeps context $ [qq|
 {imports $ standardImports context}
 
 {fromImports $ localImports context}
@@ -714,7 +718,9 @@ compileModule source =
     require :: T.Text -> T.Text -> S.Set T.Text -> S.Set T.Text
     require pkg module' set =
         if set `has` module' then S.singleton pkg else S.empty
-    codeWithDeps :: CodeGenContext -> Code -> Either CompileError (InstallRequires, Code)
+    codeWithDeps :: CodeGenContext
+                 -> Code
+                 -> Either CompileError (InstallRequires, Code)
     codeWithDeps context c = Right (InstallRequires deps optDeps, c)
       where
         deps :: S.Set T.Text

--- a/test/Nirum/CliSpec.hs
+++ b/test/Nirum/CliSpec.hs
@@ -17,7 +17,7 @@ import Nirum.Cli (writeFiles)
 expectWriteFiles :: FilePath -> [(FilePath, Text)] -> IO [FilePath]
 expectWriteFiles tmpDir files = do
     writeFiles tmpDir $ M.fromList [(f, Right c) | (f, c) <- files]
-    forM_ files $ \(f, expectedContent) -> do
+    forM_ files $ \ (f, expectedContent) -> do
         content <- TI.readFile (tmpDir </> f)
         content `shouldBe` expectedContent
     fileList <- listDirectory tmpDir
@@ -27,14 +27,14 @@ spec :: Spec
 spec =
     describe "writeFiles" $ do
         it "writes root files" $
-            withSystemTempDirectory "writeFiles-rootFiles" $ \tmpDir -> do
+            withSystemTempDirectory "writeFiles-rootFiles" $ \ tmpDir -> do
                 let files = [ ("a.txt", "content A")
                             , ("b.txt", "content B")
                             ]
                 fileList <- expectWriteFiles tmpDir files
                 fileList `shouldBe` sort [f | (f, _) <- files]
         it "makes directories if necessary" $
-            withSystemTempDirectory "writeFiles-directories" $ \tmpDir -> do
+            withSystemTempDirectory "writeFiles-directories" $ \ tmpDir -> do
                 let files = [ ("a.txt", "content A")
                             , ("b.txt", "content B")
                             , ("d/a.txt", "content d/a")

--- a/test/Nirum/CodeGenSpec.hs
+++ b/test/Nirum/CodeGenSpec.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE FlexibleInstances, ScopedTypeVariables, RankNTypes, MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances, ScopedTypeVariables, RankNTypes,
+             MultiParamTypeClasses #-}
 module Nirum.CodeGenSpec where
 
 import Control.Monad.Except (throwError)
@@ -13,7 +14,7 @@ import Nirum.CodeGen (CodeGen, Failure, fromString, runCodeGen)
 data SampleError = SampleError Text
     deriving (Eq, Ord, Show)
 
-instance forall s. Failure s SampleError where
+instance forall s . Failure s SampleError where
     fromString = return . SampleError . T.pack
 
 
@@ -21,19 +22,19 @@ spec :: Spec
 spec = parallel $ do
     specify "fail" $ do
         let codeGen' :: CodeGen Integer SampleError () = do
-                modify (+1)
-                modify (+1)
+                modify (+ 1)
+                modify (+ 1)
                 fail "test"
         runCodeGen codeGen' 0 `shouldBe` (Left (SampleError "test"), 2)
         let codeGen'' :: CodeGen Integer SampleError Integer = do
-                modify (+1)
+                modify (+ 1)
                 _ <- fail "test"
-                modify (+1)
+                modify (+ 1)
                 return 42
         runCodeGen codeGen'' 0 `shouldBe` (Left (SampleError "test"), 1)
     specify "throwError" $ do
         let codeGen' :: CodeGen Integer SampleError () = do
-                modify (+1)
+                modify (+ 1)
                 _ <- throwError $ SampleError "test"
-                modify (+2)
+                modify (+ 2)
         runCodeGen codeGen' 0 `shouldBe` (Left (SampleError "test"), 1)

--- a/test/Nirum/Constructs/AnnotationSpec.hs
+++ b/test/Nirum/Constructs/AnnotationSpec.hs
@@ -58,11 +58,12 @@ spec = do
             let Right a = fromList [annotation, loremAnno]
             let Right b = fromList [docsAnno, escapeCharAnno]
             let c = AnnotationSet [("foo", Just "bar")]
-            A.union a b `shouldBe` AnnotationSet [ ("foo", Nothing)
-                                                 , ("lorem", Just "ipsum")
-                                                 , ("quote", Just "\"")
-                                                 , ("docs", Just "Description\n")
-                                                 ]
+            A.union a b `shouldBe`
+                AnnotationSet [ ("foo", Nothing)
+                              , ("lorem", Just "ipsum")
+                              , ("quote", Just "\"")
+                              , ("docs", Just "Description\n")
+                              ]
             A.union a c `shouldBe` a
         let Right annotationSet = fromList [ annotation
                                            , loremAnno
@@ -78,8 +79,10 @@ spec = do
                 A.lookup "FOO" annotationSet `shouldBe` Just annotation
                 A.lookup "lorem" annotationSet `shouldBe` Just loremAnno
                 A.lookup "quote" annotationSet `shouldBe` Just escapeCharAnno
-                A.lookup "long-cat-is-long" annotationSet `shouldBe` Just longNameAnno
-                A.lookup "long_cat_is_long" annotationSet `shouldBe` Just longNameAnno
+                A.lookup "long-cat-is-long" annotationSet
+                    `shouldBe` Just longNameAnno
+                A.lookup "long_cat_is_long" annotationSet
+                    `shouldBe` Just longNameAnno
                 A.lookup "docs" annotationSet `shouldBe` Just docsAnno
             it "should be Nothing if lookup fails" $ do
                 A.lookup "bar" annotationSet `shouldBe` Nothing

--- a/test/Nirum/Constructs/DeclarationSetSpec.hs
+++ b/test/Nirum/Constructs/DeclarationSetSpec.hs
@@ -1,17 +1,17 @@
 {-# LANGUAGE OverloadedLists #-}
-module Nirum.Constructs.DeclarationSetSpec (SampleDecl(..), spec) where
+module Nirum.Constructs.DeclarationSetSpec (SampleDecl (..), spec) where
 
 import Control.Exception.Base (evaluate)
-import Data.String (IsString(..))
+import Data.String (IsString (..))
 
 import Test.Hspec.Meta
 
-import Nirum.Constructs (Construct(..))
+import Nirum.Constructs (Construct (..))
 import qualified Nirum.Constructs.Annotation as A
 import Nirum.Constructs.Annotation (AnnotationSet)
-import Nirum.Constructs.Declaration (Declaration(..))
+import Nirum.Constructs.Declaration (Declaration (..))
 import Nirum.Constructs.DeclarationSet ( DeclarationSet
-                                       , NameDuplication(..)
+                                       , NameDuplication (..)
                                        , empty
                                        , fromList
                                        , lookup'
@@ -21,7 +21,7 @@ import Nirum.Constructs.DeclarationSet ( DeclarationSet
                                        , union
                                        , (!)
                                        )
-import Nirum.Constructs.Name (Name(Name))
+import Nirum.Constructs.Name (Name (Name))
 
 data SampleDecl = SampleDecl Name AnnotationSet deriving (Eq, Ord, Show)
 

--- a/test/Nirum/Constructs/DocsSpec.hs
+++ b/test/Nirum/Constructs/DocsSpec.hs
@@ -2,8 +2,8 @@ module Nirum.Constructs.DocsSpec where
 
 import Test.Hspec.Meta
 
-import Nirum.Constructs (Construct(..))
-import Nirum.Constructs.Docs (Docs(Docs), toCodeWithPrefix)
+import Nirum.Constructs (Construct (..))
+import Nirum.Constructs.Docs (Docs (Docs), toCodeWithPrefix)
 
 spec :: Spec
 spec =

--- a/test/Nirum/Constructs/IdentifierSpec.hs
+++ b/test/Nirum/Constructs/IdentifierSpec.hs
@@ -51,8 +51,8 @@ spec = do
                 `shouldBe` Nothing
             fromText "identifier_cannot_have_two__or_more_continued_underscores"
                 `shouldBe` Nothing
-            fromText "무효한-식별자" `shouldBe` Nothing
-            fromText "invalid-식별자" `shouldBe` Nothing
+            fromText "\xbb34\xd6a8\xd55c-\xc2dd\xbcc4\xc790" `shouldBe` Nothing
+            fromText "invalid-\xc2dd\xbcc4\xc790" `shouldBe` Nothing
             fromText "identifier cannot contain whitepsaces" `shouldBe` Nothing
         it "returns Just Identifier if nothing goes wrong" $ do
             toText "datetime" `shouldBe` "datetime"
@@ -109,7 +109,7 @@ spec = do
         let normalizers = [ toNormalizedText
                           , toLispCaseText
                           ] :: [Identifier -> Text]
-        forM_ normalizers $ \normalizer -> do
+        forM_ normalizers $ \ normalizer -> do
             it "returns lowercased identifier text" $ do
                 normalizer "IDENTIFIER" `shouldBe` "identifier"
                 normalizer "Identifier" `shouldBe` "identifier"

--- a/test/Nirum/Constructs/ModulePathSpec.hs
+++ b/test/Nirum/Constructs/ModulePathSpec.hs
@@ -3,13 +3,13 @@ module Nirum.Constructs.ModulePathSpec where
 
 import Control.Exception (evaluate)
 import Data.List (sort)
-import GHC.Exts (IsList(fromList, toList))
+import GHC.Exts (IsList (fromList, toList))
 
 import System.FilePath ((</>))
 import Test.Hspec.Meta
 
-import Nirum.Constructs (Construct(toCode))
-import Nirum.Constructs.ModulePath ( ModulePath(ModuleName, ModulePath)
+import Nirum.Constructs (Construct (toCode))
+import Nirum.Constructs.ModulePath ( ModulePath (ModuleName, ModulePath)
                                    , ancestors
                                    , fromFilePath
                                    , fromIdentifiers

--- a/test/Nirum/Constructs/ModuleSpec.hs
+++ b/test/Nirum/Constructs/ModuleSpec.hs
@@ -4,14 +4,14 @@ module Nirum.Constructs.ModuleSpec where
 import Test.Hspec.Meta
 import Text.InterpolatedString.Perl6 (q)
 
-import Nirum.Constructs (Construct(toCode))
+import Nirum.Constructs (Construct (toCode))
 import Nirum.Constructs.Annotation as A (docs, empty, singleton)
 import Nirum.Constructs.DeclarationSet (DeclarationSet)
-import Nirum.Constructs.Module (Module(..), imports)
-import Nirum.Constructs.TypeDeclaration ( Type(..)
-                                        , TypeDeclaration( Import
-                                                         , TypeDeclaration
-                                                         )
+import Nirum.Constructs.Module (Module (..), imports)
+import Nirum.Constructs.TypeDeclaration ( Type (..)
+                                        , TypeDeclaration ( Import
+                                                          , TypeDeclaration
+                                                          )
                                         )
 
 spec :: Spec

--- a/test/Nirum/Constructs/NameSpec.hs
+++ b/test/Nirum/Constructs/NameSpec.hs
@@ -2,7 +2,7 @@ module Nirum.Constructs.NameSpec where
 
 import Test.Hspec.Meta
 
-import Nirum.Constructs.Name (Name(Name), isComplex, isSimple, toCode)
+import Nirum.Constructs.Name (Name (Name), isComplex, isSimple, toCode)
 
 spec :: Spec
 spec =

--- a/test/Nirum/Constructs/ServiceSpec.hs
+++ b/test/Nirum/Constructs/ServiceSpec.hs
@@ -1,15 +1,16 @@
-{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedLists, QuasiQuotes #-}
 module Nirum.Constructs.ServiceSpec where
 
+import Data.String.QQ (s)
 import Test.Hspec.Meta
 
-import Nirum.Constructs.Annotation (Annotation (Annotation)
+import Nirum.Constructs.Annotation ( Annotation (Annotation)
                                    , empty
                                    , fromList
                                    , union
                                    )
 import Nirum.Constructs.Docs (toCode)
-import Nirum.Constructs.Service (Method(Method), Parameter(Parameter))
+import Nirum.Constructs.Service (Method (Method), Parameter (Parameter))
 import Nirum.Constructs.TypeExpression ( TypeExpression ( ListModifier
                                                         , OptionModifier
                                                         )
@@ -78,46 +79,50 @@ spec = do
                            [Parameter "user-id" "uuid" empty]
                            (OptionModifier "user")
                            (Just "get-user-error")
-                           docsAnno) `shouldBe`
-                "user? get-user (\n\
-                \  # docs...\n\
-                \  uuid user-id,\n\
-                \) throws get-user-error,"
+                           docsAnno) `shouldBe` [s|
+user? get-user (
+  # docs...
+  uuid user-id,
+) throws get-user-error,|]
             toCode (Method "get-user"
-                           [Parameter "user-id" "uuid" $ singleDocs "param docs..."]
+                           [Parameter "user-id" "uuid" $
+                                      singleDocs "param docs..."]
                            (OptionModifier "user")
                            Nothing
                            empty) `shouldBe`
                 "user? get-user (\n  uuid user-id,\n  # param docs...\n),"
             toCode (Method "get-user"
-                           [Parameter "user-id" "uuid" $ singleDocs "param docs..."]
+                           [Parameter "user-id" "uuid" $
+                                      singleDocs "param docs..."]
                            (OptionModifier "user")
                            Nothing
-                           docsAnno) `shouldBe`
-                "user? get-user (\n\
-                \  # docs...\n\
-                \  uuid user-id,\n\
-                \  # param docs...\n\
-                \),"
+                           docsAnno) `shouldBe` [s|
+user? get-user (
+  # docs...
+  uuid user-id,
+  # param docs...
+),|]
             toCode (Method "get-user"
-                           [Parameter "user-id" "uuid" $ singleDocs "param docs..."]
+                           [Parameter "user-id" "uuid" $
+                                      singleDocs "param docs..."]
                            (OptionModifier "user")
                            (Just "get-user-error")
-                           empty) `shouldBe`
-                "user? get-user (\n\
-                \  uuid user-id,\n\
-                \  # param docs...\n\
-                \) throws get-user-error,"
+                           empty) `shouldBe` [s|
+user? get-user (
+  uuid user-id,
+  # param docs...
+) throws get-user-error,|]
             toCode (Method "get-user"
-                           [Parameter "user-id" "uuid" $ singleDocs "param docs..."]
+                           [Parameter "user-id" "uuid" $
+                                      singleDocs "param docs..."]
                            (OptionModifier "user")
                            (Just "get-user-error")
-                           docsAnno) `shouldBe`
-                "user? get-user (\n\
-                \  # docs...\n\
-                \  uuid user-id,\n\
-                \  # param docs...\n\
-                \) throws get-user-error,"
+                           docsAnno) `shouldBe` [s|
+user? get-user (
+  # docs...
+  uuid user-id,
+  # param docs...
+) throws get-user-error,|]
             toCode (Method "search-posts"
                            [ Parameter "blog-id" "uuid" empty
                            , Parameter "keyword" "text" empty
@@ -132,101 +137,111 @@ spec = do
                            ]
                            (ListModifier "post")
                            Nothing
-                           docsAnno) `shouldBe`
-                "[post] search-posts (\n\
-                \  # docs...\n\
-                \  uuid blog-id,\n\
-                \  text keyword,\n\
-                \),"
+                           docsAnno) `shouldBe` [s|
+[post] search-posts (
+  # docs...
+  uuid blog-id,
+  text keyword,
+),|]
             toCode (Method "search-posts"
                            [ Parameter "blog-id" "uuid" empty
                            , Parameter "keyword" "text" empty
                            ]
                            (ListModifier "post")
                            (Just "search-posts-error")
-                           empty) `shouldBe`
-                "[post] search-posts (\n\
-                \  uuid blog-id,\n\
-                \  text keyword,\n\
-                \) throws search-posts-error,"
+                           empty) `shouldBe` [s|
+[post] search-posts (
+  uuid blog-id,
+  text keyword,
+) throws search-posts-error,|]
             toCode (Method "search-posts"
                            [ Parameter "blog-id" "uuid" empty
                            , Parameter "keyword" "text" empty
                            ]
                            (ListModifier "post")
                            (Just "search-posts-error")
-                           docsAnno) `shouldBe`
-                "[post] search-posts (\n\
-                \  # docs...\n\
-                \  uuid blog-id,\n\
-                \  text keyword,\n\
-                \) throws search-posts-error,"
+                           docsAnno) `shouldBe` [s|
+[post] search-posts (
+  # docs...
+  uuid blog-id,
+  text keyword,
+) throws search-posts-error,|]
             toCode (Method "search-posts"
-                           [ Parameter "blog-id" "uuid" $ singleDocs "blog id..."
-                           , Parameter "keyword" "text" $ singleDocs "keyword..."
+                           [ Parameter "blog-id" "uuid" $
+                                       singleDocs "blog id..."
+                           , Parameter "keyword" "text" $
+                                       singleDocs "keyword..."
                            ]
                            (ListModifier "post")
                            Nothing
-                           empty) `shouldBe`
-                "[post] search-posts (\n\
-                \  uuid blog-id,\n\
-                \  # blog id...\n\
-                \  text keyword,\n\
-                \  # keyword...\n\
-                \),"
+                           empty) `shouldBe` [s|
+[post] search-posts (
+  uuid blog-id,
+  # blog id...
+  text keyword,
+  # keyword...
+),|]
             toCode (Method "search-posts"
-                           [ Parameter "blog-id" "uuid" $ singleDocs "blog id..."
-                           , Parameter "keyword" "text" $ singleDocs "keyword..."
+                           [ Parameter "blog-id" "uuid" $
+                                       singleDocs "blog id..."
+                           , Parameter "keyword" "text" $
+                                       singleDocs "keyword..."
                            ]
                            (ListModifier "post")
                            Nothing
-                           docsAnno) `shouldBe`
-                "[post] search-posts (\n\
-                \  # docs...\n\
-                \  uuid blog-id,\n\
-                \  # blog id...\n\
-                \  text keyword,\n\
-                \  # keyword...\n\
-                \),"
+                           docsAnno) `shouldBe` [s|
+[post] search-posts (
+  # docs...
+  uuid blog-id,
+  # blog id...
+  text keyword,
+  # keyword...
+),|]
             toCode (Method "search-posts"
-                           [ Parameter "blog-id" "uuid" $ singleDocs "blog id..."
-                           , Parameter "keyword" "text" $ singleDocs "keyword..."
+                           [ Parameter "blog-id" "uuid" $
+                                       singleDocs "blog id..."
+                           , Parameter "keyword" "text" $
+                                       singleDocs "keyword..."
                            ]
                            (ListModifier "post")
                            (Just "search-posts-error")
-                           empty) `shouldBe`
-                "[post] search-posts (\n\
-                \  uuid blog-id,\n\
-                \  # blog id...\n\
-                \  text keyword,\n\
-                \  # keyword...\n\
-                \) throws search-posts-error,"
+                           empty) `shouldBe` [s|
+[post] search-posts (
+  uuid blog-id,
+  # blog id...
+  text keyword,
+  # keyword...
+) throws search-posts-error,|]
             toCode (Method "search-posts"
-                           [ Parameter "blog-id" "uuid" $ singleDocs "blog id..."
-                           , Parameter "keyword" "text" $ singleDocs "keyword..."
+                           [ Parameter "blog-id" "uuid" $
+                                       singleDocs "blog id..."
+                           , Parameter "keyword" "text" $
+                                       singleDocs "keyword..."
                            ]
                            (ListModifier "post")
                            (Just "search-posts-error")
-                           docsAnno) `shouldBe`
-                "[post] search-posts (\n\
-                \  # docs...\n\
-                \  uuid blog-id,\n\
-                \  # blog id...\n\
-                \  text keyword,\n\
-                \  # keyword...\n\
-                \) throws search-posts-error,"
+                           docsAnno) `shouldBe` [s|
+[post] search-posts (
+  # docs...
+  uuid blog-id,
+  # blog id...
+  text keyword,
+  # keyword...
+) throws search-posts-error,|]
             toCode (Method "search-posts"
-                           [ Parameter "blog-id" "uuid" $ singleDocs "blog id..."
-                           , Parameter "keyword" "text" $ singleDocs "keyword..."
+                           [ Parameter "blog-id" "uuid" $
+                                       singleDocs "blog id..."
+                           , Parameter "keyword" "text" $
+                                       singleDocs "keyword..."
                            ]
                            (ListModifier "post")
                            (Just "search-posts-error")
-                           (docsAnno `union` methodAnno)) `shouldBe`
-                "@http-get(\"/ping/\")\n\
-                \[post] search-posts (\n\
-                \  # docs...\n\
-                \  uuid blog-id,\n\
-                \  # blog id...\n\
-                \  text keyword,\n\
-                \  # keyword...\n\
-                \) throws search-posts-error,"
+                           (docsAnno `union` methodAnno)) `shouldBe` [s|
+@http-get("/ping/")
+[post] search-posts (
+  # docs...
+  uuid blog-id,
+  # blog id...
+  text keyword,
+  # keyword...
+) throws search-posts-error,|]

--- a/test/Nirum/Constructs/TypeDeclarationSpec.hs
+++ b/test/Nirum/Constructs/TypeDeclarationSpec.hs
@@ -1,26 +1,27 @@
-{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedLists, QuasiQuotes #-}
 module Nirum.Constructs.TypeDeclarationSpec where
 
 import Data.Either (rights)
+import Data.String.QQ (s)
 import qualified Data.Text as T
 import Test.Hspec.Meta
 
-import Nirum.Constructs (Construct(toCode))
+import Nirum.Constructs (Construct (toCode))
 import Nirum.Constructs.Annotation ( Annotation (Annotation)
                                    , AnnotationSet
                                    , fromList
                                    , empty
                                    )
-import Nirum.Constructs.Declaration (Declaration(name), docs)
+import Nirum.Constructs.Declaration (Declaration (name), docs)
 import Nirum.Constructs.DeclarationSet (DeclarationSet)
-import Nirum.Constructs.Service (Method(Method), Service(Service))
-import Nirum.Constructs.TypeDeclaration ( EnumMember(EnumMember)
-                                        , Field(Field)
-                                        , JsonType(String)
-                                        , PrimitiveTypeIdentifier(Text)
-                                        , Tag(Tag)
-                                        , Type(..)
-                                        , TypeDeclaration(..)
+import Nirum.Constructs.Service (Method (Method), Service (Service))
+import Nirum.Constructs.TypeDeclaration ( EnumMember (EnumMember)
+                                        , Field (Field)
+                                        , JsonType (String)
+                                        , PrimitiveTypeIdentifier (Text)
+                                        , Tag (Tag)
+                                        , Type (..)
+                                        , TypeDeclaration (..)
                                         )
 import Util (singleDocs)
 
@@ -74,21 +75,23 @@ spec = do
                                     }
                 b = a { typeAnnotations = singleDocs "country codes" }
             specify "toCode" $ do
-                toCode a `shouldBe` "enum country\n\
-                                    \    = kr\n\
-                                    \    | jp\n\
-                                    \    # Japan\n\
-                                    \    | us\n\
-                                    \    # United States\n\
-                                    \    ;"
-                toCode b `shouldBe` "enum country\n\
-                                    \    # country codes\n\
-                                    \    = kr\n\
-                                    \    | jp\n\
-                                    \    # Japan\n\
-                                    \    | us\n\
-                                    \    # United States\n\
-                                    \    ;"
+                toCode a `shouldBe` [s|
+enum country
+    = kr
+    | jp
+    # Japan
+    | us
+    # United States
+    ;|]
+                toCode b `shouldBe` [s|
+enum country
+    # country codes
+    = kr
+    | jp
+    # Japan
+    | us
+    # United States
+    ;|]
         context "RecordType" $ do
             let fields' = [ Field "name" "text" empty
                           , Field "dob" "date" (singleDocs "date of birth")
@@ -101,19 +104,22 @@ spec = do
                                     }
                 b = a { typeAnnotations = singleDocs "person record type" }
             specify "toCode" $ do
-                toCode a `shouldBe` "record person (\n\
-                                    \    text name,\n\
-                                    \    date dob,\n\
-                                    \    # date of birth\n\
-                                    \    gender gender,\n\
-                                    \);"
-                toCode b `shouldBe` "record person (\n\
-                                    \    # person record type\n\n\
-                                    \    text name,\n\
-                                    \    date dob,\n\
-                                    \    # date of birth\n\
-                                    \    gender gender,\n\
-                                    \);"
+                toCode a `shouldBe` [s|
+record person (
+    text name,
+    date dob,
+    # date of birth
+    gender gender,
+);|]
+                toCode b `shouldBe` [s|
+record person (
+    # person record type
+
+    text name,
+    date dob,
+    # date of birth
+    gender gender,
+);|]
         context "UnionType" $ do
             let circleFields = [ Field "origin" "point" empty
                                , Field "radius" "offset" empty
@@ -132,21 +138,19 @@ spec = do
                                     }
                 b = a { typeAnnotations = singleDocs "shape type" }
             specify "toCode" $ do
-                toCode a `shouldBe` "union shape\n\
-                                    \    = circle (point origin, \
-                                                  \offset radius,)\n\
-                                    \    | rectangle (point upper-left, \
-                                                     \point lower-right,)\n\
-                                    \    | none\n\
-                                    \    ;"
-                toCode b `shouldBe` "union shape\n\
-                                    \    # shape type\n\
-                                    \    = circle (point origin, \
-                                                  \offset radius,)\n\
-                                    \    | rectangle (point upper-left, \
-                                                     \point lower-right,)\n\
-                                    \    | none\n\
-                                    \    ;"
+                toCode a `shouldBe` [s|
+union shape
+    = circle (point origin, offset radius,)
+    | rectangle (point upper-left, point lower-right,)
+    | none
+    ;|]
+                toCode b `shouldBe` [s|
+union shape
+    # shape type
+    = circle (point origin, offset radius,)
+    | rectangle (point upper-left, point lower-right,)
+    | none
+    ;|]
         context "PrimitiveType" $ do
             let primitiveType = PrimitiveType Text String
                 decl = TypeDeclaration "text" primitiveType empty
@@ -168,19 +172,19 @@ spec = do
                                               barAnnotationSet
             specify "toCode" $ do
                 toCode nullDecl `shouldBe` "service null-service ();"
-                toCode nullDecl' `shouldBe` "service null-service (\n\
-                                            \    # Null service declaration.\n\
-                                            \);"
+                toCode nullDecl' `shouldBe` [s|
+service null-service (
+    # Null service declaration.
+);|]
                 toCode pingDecl `shouldBe`
                     "service ping-service (bool ping ());"
-                toCode pingDecl' `shouldBe`
-                    "service ping-service (\n\
-                    \    # Ping service declaration.\n\
-                    \    bool ping ()\n\
-                    \);"
+                toCode pingDecl' `shouldBe` [s|
+service ping-service (
+    # Ping service declaration.
+    bool ping ()
+);|]
                 toCode annoDecl `shouldBe`
-                    "@bar(\"baz\")\n\
-                    \service anno-service (bool ping ());"
+                    "@bar(\"baz\")\nservice anno-service (bool ping ());"
                 -- TODO: more tests
         context "Import" $ do
             let import' = Import ["foo", "bar"] "baz" empty

--- a/test/Nirum/Constructs/TypeExpressionSpec.hs
+++ b/test/Nirum/Constructs/TypeExpressionSpec.hs
@@ -2,7 +2,7 @@ module Nirum.Constructs.TypeExpressionSpec where
 
 import Test.Hspec.Meta
 
-import Nirum.Constructs.TypeExpression (TypeExpression(..), toCode)
+import Nirum.Constructs.TypeExpression (TypeExpression (..), toCode)
 
 spec :: Spec
 spec =

--- a/test/Nirum/Package/ModuleSetSpec.hs
+++ b/test/Nirum/Package/ModuleSetSpec.hs
@@ -40,10 +40,10 @@ validModules =
       , Module [TypeDeclaration "a" (Alias "text") empty]
                Nothing
       )
-    , (["foo"],        Module [] $ Just "foo")
+    , (["foo"], Module [] $ Just "foo")
     , (["foo", "bar"], fooBarModule)
     , (["foo", "baz"], Module [] $ Just "foo.baz")
-    , (["qux"],        Module [] $ Just "qux")
+    , (["qux"], Module [] $ Just "qux")
     , ( ["xyz"]
       , Module [ Import ["abc"] "a" empty
                , TypeDeclaration "x" (Alias "text") empty

--- a/test/Nirum/PackageSpec.hs
+++ b/test/Nirum/PackageSpec.hs
@@ -11,19 +11,19 @@ import qualified Text.Parsec.Error as PE
 import Text.Parsec.Pos (sourceColumn, sourceLine)
 
 import Nirum.Constructs.Annotation (empty)
-import Nirum.Constructs.Module (Module(Module), coreModulePath)
+import Nirum.Constructs.Module (Module (Module), coreModulePath)
 import Nirum.Constructs.ModulePath (ModulePath)
-import Nirum.Constructs.TypeDeclaration ( JsonType(String)
-                                        , PrimitiveTypeIdentifier(Text)
-                                        , Type(Alias, PrimitiveType)
+import Nirum.Constructs.TypeDeclaration ( JsonType (String)
+                                        , PrimitiveTypeIdentifier (Text)
+                                        , Type (Alias, PrimitiveType)
                                         , TypeDeclaration ( Import
                                                           , TypeDeclaration
                                                           )
                                         )
-import Nirum.Package ( BoundModule(boundPackage, modulePath)
+import Nirum.Package ( BoundModule (boundPackage, modulePath)
                      , Package (Package)
                      , PackageError (ImportError, MetadataError, ScanError)
-                     , TypeLookup(Imported, Local, Missing)
+                     , TypeLookup (Imported, Local, Missing)
                      , docs
                      , lookupType
                      , resolveBoundModule

--- a/test/Nirum/Targets/PythonSpec.hs
+++ b/test/Nirum/Targets/PythonSpec.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedLists, QuasiQuotes, ScopedTypeVariables #-}
-{-|
+{- |
 This unit test module optionally depends on Python interpreter.
 It internally tries to popen python3 executable, and import nirum Python
 package.  If any of these prerequisites are not satisfied, tests depending
@@ -29,11 +29,11 @@ import qualified Data.SemVer as SV
 import qualified Data.Text as T
 import qualified Data.Text.IO as TI
 import System.Directory (createDirectoryIfMissing)
-import System.Exit (ExitCode(ExitSuccess))
+import System.Exit (ExitCode (ExitSuccess))
 import System.FilePath (isValid, takeDirectory, (</>))
 import System.Info (os)
 import System.IO.Temp (withSystemTempDirectory)
-import System.Process ( CreateProcess(cwd)
+import System.Process ( CreateProcess (cwd)
                       , proc
                       , readCreateProcess
                       , readCreateProcessWithExitCode
@@ -47,36 +47,36 @@ import Text.Megaparsec.String (Parser)
 import Nirum.Constructs.Annotation (empty)
 import Nirum.Constructs.DeclarationSet (DeclarationSet)
 import Nirum.Constructs.Identifier (Identifier)
-import Nirum.Constructs.Module (Module(Module))
+import Nirum.Constructs.Module (Module (Module))
 import Nirum.Constructs.ModulePath (ModulePath, fromIdentifiers)
-import Nirum.Constructs.Name (Name(Name))
+import Nirum.Constructs.Name (Name (Name))
 import Nirum.Constructs.Service ( Method (Method)
                                 , Parameter (Parameter)
                                 , Service (Service)
                                 )
-import Nirum.Constructs.TypeDeclaration ( Field(Field)
-                                        , EnumMember(EnumMember)
-                                        , PrimitiveTypeIdentifier(..)
-                                        , Tag(Tag)
-                                        , Type( Alias
-                                              , EnumType
-                                              , RecordType
-                                              , UnboxedType
-                                              , UnionType
-                                              )
+import Nirum.Constructs.TypeDeclaration ( Field (Field)
+                                        , EnumMember (EnumMember)
+                                        , PrimitiveTypeIdentifier (..)
+                                        , Tag (Tag)
+                                        , Type ( Alias
+                                               , EnumType
+                                               , RecordType
+                                               , UnboxedType
+                                               , UnionType
+                                               )
                                         , TypeDeclaration ( Import
                                                           , ServiceDeclaration
                                                           , TypeDeclaration
                                                           )
                                         )
-import Nirum.Constructs.TypeExpression ( TypeExpression( ListModifier
-                                                       , MapModifier
-                                                       , OptionModifier
-                                                       , SetModifier
-                                                       , TypeIdentifier
-                                                       )
+import Nirum.Constructs.TypeExpression ( TypeExpression ( ListModifier
+                                                        , MapModifier
+                                                        , OptionModifier
+                                                        , SetModifier
+                                                        , TypeIdentifier
+                                                        )
                                        )
-import Nirum.Package (BoundModule(modulePath), Package, resolveBoundModule)
+import Nirum.Package (BoundModule (modulePath), Package, resolveBoundModule)
 import Nirum.Package.Metadata ( Author (Author, email, name, uri)
                               , Metadata (Metadata, authors, version)
                               )
@@ -127,9 +127,14 @@ installedPythonPaths cwd' = do
         _ -> []
   where
     proc' :: CreateProcess
-    proc' = (if windows then proc "where.exe" ["python"] else proc "which" ["python3"]) { cwd = cwd' }
+    proc' = (if windows
+             then proc "where.exe" ["python"]
+             else proc "which" ["python3"]) { cwd = cwd' }
     lines' :: String -> [String]
-    lines' = map T.unpack . filter (not . T.null) . map T.strip . T.lines . T.pack
+    lines' = map T.unpack . filter (not . T.null)
+                          . map T.strip
+                          . T.lines
+                          . T.pack
 
 getPythonVersion :: Maybe FilePath -> FilePath -> IO (Maybe PyVersion)
 getPythonVersion cwd' path' = do
@@ -158,7 +163,7 @@ findPython :: Maybe FilePath -> IO (Maybe FilePath)
 findPython cwd' = installedPythonPaths cwd' >>= findPython'
   where
     findPython' :: [FilePath] -> IO (Maybe FilePath)
-    findPython' (x:xs) = do
+    findPython' (x : xs) = do
         pyVerM <- getPythonVersion cwd' x
         case pyVerM of
             Nothing -> findPython' xs
@@ -188,7 +193,7 @@ runPython' cwd' args stdinStr = do
 
 runPython :: Maybe FilePath -> String -> IO (Maybe String)
 runPython cwd' code' =
-    catchIOError (runPython' cwd' [] code') $ \e -> do
+    catchIOError (runPython' cwd' [] code') $ \ e -> do
         putStrLn "\nThe following IO error was raised:\n"
         putStrLn $ indent "  " $ show e
         putStrLn "\n... while the following code was executed:\n"
@@ -217,8 +222,8 @@ else: print('T')
                                 expectationFailure $
                                 T.unpack ("Test failed: " `T.append` testCode)
                         Nothing -> return ()
-                _ -> putStrLn "The nirum Python package cannot be imported; \
-                              \skipped..."
+                _ -> putStrLn ("The nirum Python package cannot be " ++
+                               "imported; skipped...")
         Nothing -> return ()
   where
     strip :: String -> String
@@ -365,7 +370,8 @@ spec = parallel $ do
         let (dateCode, dateContext) = run' (compilePrimitiveType Date)
         dateCode `shouldBe` Right "datetime.date"
         standardImports dateContext `shouldBe` ["datetime"]
-        let (datetimeCode, datetimeContext) = run' (compilePrimitiveType Datetime)
+        let (datetimeCode, datetimeContext) =
+                run' (compilePrimitiveType Datetime)
         datetimeCode `shouldBe` Right "datetime.datetime"
         standardImports datetimeContext `shouldBe` ["datetime"]
         let (uuidCode, uuidContext) = run' (compilePrimitiveType Uuid)
@@ -376,27 +382,32 @@ spec = parallel $ do
     describe "compileTypeExpression" $ do
         let s = makeDummySource $ Module [] Nothing
         specify "TypeIdentifier" $ do
-            let (c, ctx) = run' $ compileTypeExpression s (TypeIdentifier "bigint")
+            let (c, ctx) = run' $
+                    compileTypeExpression s (TypeIdentifier "bigint")
             standardImports ctx `shouldBe` []
             localImports ctx `shouldBe` []
             c `shouldBe` Right "int"
         specify "OptionModifier" $ do
-            let (c', ctx') = run' $ compileTypeExpression s (OptionModifier "text")
+            let (c', ctx') = run' $
+                    compileTypeExpression s (OptionModifier "text")
             standardImports ctx' `shouldBe` ["typing"]
             localImports ctx' `shouldBe` []
             c' `shouldBe` Right "typing.Optional[str]"
         specify "SetModifier" $ do
-            let (c'', ctx'') = run' $ compileTypeExpression s (SetModifier "text")
+            let (c'', ctx'') = run' $
+                    compileTypeExpression s (SetModifier "text")
             standardImports ctx'' `shouldBe` ["typing"]
             localImports ctx'' `shouldBe` []
             c'' `shouldBe` Right "typing.AbstractSet[str]"
         specify "ListModifier" $ do
-            let (c''', ctx''') = run' $ compileTypeExpression s (ListModifier "text")
+            let (c''', ctx''') = run' $
+                    compileTypeExpression s (ListModifier "text")
             standardImports ctx''' `shouldBe` ["typing"]
             localImports ctx''' `shouldBe` []
             c''' `shouldBe` Right "typing.Sequence[str]"
         specify "MapModifier" $ do
-            let (c'''', ctx'''') = run' $ compileTypeExpression s (MapModifier "uuid" "text")
+            let (c'''', ctx'''') = run' $
+                    compileTypeExpression s (MapModifier "uuid" "text")
             standardImports ctx'''' `shouldBe` ["uuid", "typing"]
             localImports ctx'''' `shouldBe` []
             c'''' `shouldBe` Right "typing.Mapping[uuid.UUID, str]"
@@ -439,22 +450,22 @@ spec = parallel $ do
             `shouldBe` [q|"Say 'hello world'"|]
         stringLiteral [q|Say "hello world"|]
             `shouldBe` [q|"Say \"hello world\""|]
-        stringLiteral [q|Say '안녕'|]
+        stringLiteral "Say '\xc548\xb155'"
             `shouldBe` [q|u"Say '\uc548\ub155'"|]
 
     let test testRunner (Source pkg boundM) testCode =
             case errors of
-                error':_ -> fail $ T.unpack error'
-                [] -> withSystemTempDirectory "nirumpy." $ \dir -> do
-                    forM_ codes $ \(filePath, code') -> do
+                error' : _ -> fail $ T.unpack error'
+                [] -> withSystemTempDirectory "nirumpy." $ \ dir -> do
+                    forM_ codes $ \ (filePath, code') -> do
                         let filePath' = dir </> filePath
                             dirName = takeDirectory filePath'
                         createDirectoryIfMissing True dirName
                         TI.writeFile filePath' code'
-                        {--  <- Remove '{' to print debug log
+                        {-- <- Remove '{' to print debug log
                         TI.putStrLn $ T.pack filePath'
                         TI.putStrLn code'
-                        -- --}
+                        -- -}
                     testRunner (Just dir) defCode testCode
           where
             files :: M.Map FilePath (Either CompileError Code)
@@ -504,7 +515,7 @@ spec = parallel $ do
                                 ] :: [(String, T.Text)]
                 source = makeDummySource $ Module [] Nothing
                 testRunner cwd' _ _ =
-                    {--  <- remove '{' to print debug log
+                    {-- -- <- remove '{' to print debug log
                     do
                         let spath = case cwd' of
                                         Just c -> c </> "setup.py"
@@ -513,8 +524,8 @@ spec = parallel $ do
                         TI.putStrLn "=========== setup.py ==========="
                         TI.putStrLn contents
                         TI.putStrLn "=========== /setup.py =========="
-                    -- --}
-                        forM_ setupPyFields $ \(option, expected) -> do
+                    -- -}
+                        forM_ setupPyFields $ \ (option, expected) -> do
                             out <- runPython' cwd' ["setup.py", option] ""
                             out `shouldSatisfy` isJust
                             let Just result = out
@@ -612,18 +623,20 @@ spec = parallel $ do
                            ] :: DeclarationSet EnumMember
                 decl' = TypeDeclaration "eva-char" (EnumType members') empty
             tT decl' "type(EvaChar) is enum.EnumMeta"
-            tT decl' "set(EvaChar) == {EvaChar.soryu_asuka_langley, \
-                                     \ EvaChar.ayanami_rei, \
-                                     \ EvaChar.ikari_shinji, \
-                                     \ EvaChar.katsuragi_misato, \
-                                     \ EvaChar.nagisa_kaworu}"
+            tT decl' [q|
+                set(EvaChar) == {EvaChar.soryu_asuka_langley,
+                                 EvaChar.ayanami_rei,
+                                 EvaChar.ikari_shinji,
+                                 EvaChar.katsuragi_misato,
+                                 EvaChar.nagisa_kaworu}
+            |]
             tT decl' "EvaChar.soryu_asuka_langley.value=='soryu_asuka_langley'"
-            tT decl' "EvaChar.soryu_asuka_langley.__nirum_serialize__() == \
-                     \ 'soryu_asuka_langley'"
-            tT decl' "EvaChar.__nirum_deserialize__('soryu_asuka_langley') == \
-                     \ EvaChar.soryu_asuka_langley"
-            tT decl' "EvaChar.__nirum_deserialize__('soryu-asuka-langley') == \
-                     \ EvaChar.soryu_asuka_langley"  -- to be robust
+            tT decl' [q|EvaChar.soryu_asuka_langley.__nirum_serialize__() ==
+                        'soryu_asuka_langley'|]
+            tT decl' [q|EvaChar.__nirum_deserialize__('soryu_asuka_langley') ==
+                        EvaChar.soryu_asuka_langley|]
+            tT decl' [q|EvaChar.__nirum_deserialize__('soryu-asuka-langley') ==
+                        EvaChar.soryu_asuka_langley|]  -- to be robust
         specify "record type" $ do
             let fields = [ Field (Name "left" "x") "bigint" empty
                          , Field "top" "bigint" empty
@@ -851,8 +864,8 @@ spec = parallel $ do
                 ping' = ServiceDeclaration "ping-service" pingService empty
             tT null' "issubclass(NullService, __import__('nirum').rpc.Service)"
             tT ping' "issubclass(PingService, __import__('nirum').rpc.Service)"
-            tT ping' "set(PingService.ping.__annotations__) == \
-                     \    {'nonce', 'return'}"
+            tT ping' [q|set(PingService.ping.__annotations__) ==
+                            {'nonce', 'return'}|]
             tT ping' "PingService.ping.__annotations__['nonce'] is str"
             tT ping' "PingService.ping.__annotations__['return'] is bool"
             tR' ping' "NotImplementedError" "PingService().ping('nonce')"


### PR DESCRIPTION
Added a lint.sh script using `hlint` and [`scan`][1] (Haskell style scanner).  The lint script is also run on Travis CI.

To make this patch itself to pass lint, it contains a lot of style adjustments as well.

[1]: http://projects.haskell.org/style-scanner/