### PR TITLE
Add Nirum.Constructs.ModulePath.spreadModulePath.

### DIFF
--- a/src/Nirum/Constructs/ModulePath.hs
+++ b/src/Nirum/Constructs/ModulePath.hs
@@ -13,7 +13,7 @@ import Data.Char (toLower)
 import Data.Maybe (fromMaybe, mapMaybe)
 import GHC.Exts (IsList (Item, fromList, toList))
 
-import Data.Set (Set, insert, singleton)
+import qualified Data.Set as S
 import Data.Text (intercalate, pack)
 import System.FilePath (splitDirectories, stripExtension)
 
@@ -55,9 +55,9 @@ fromFilePath filePath =
     fileIdentifiers :: [Identifier]
     fileIdentifiers = mapMaybe (fromText . pack) paths
 
-ancestors :: ModulePath -> Set ModulePath
-ancestors m@ModuleName {} = singleton m
-ancestors m@(ModulePath parent _) = m `insert` ancestors parent
+ancestors :: ModulePath -> S.Set ModulePath
+ancestors m@ModuleName {} = S.singleton m
+ancestors m@(ModulePath parent _) = m `S.insert` ancestors parent
 
 instance IsList ModulePath where
     type Item ModulePath = Identifier

--- a/src/Nirum/Constructs/ModulePath.hs
+++ b/src/Nirum/Constructs/ModulePath.hs
@@ -7,6 +7,7 @@ module Nirum.Constructs.ModulePath ( ModulePath ( ModuleName
                                    , ancestors
                                    , fromFilePath
                                    , fromIdentifiers
+                                   , hierarchy
                                    ) where
 
 import Data.Char (toLower)
@@ -66,3 +67,10 @@ instance IsList ModulePath where
                   (fromIdentifiers identifiers)
     toList (ModuleName identifier) = [identifier]
     toList (ModulePath path' identifier) = toList path' ++ [identifier]
+
+hierarchy :: ModulePath -> S.Set [Identifier]
+hierarchy modulePath' = S.fromList $ toPathList modulePath'
+  where
+    toPathList :: ModulePath -> [[Identifier]]
+    toPathList m@(ModulePath path' _) = toList m : toPathList path'
+    toPathList (ModuleName identifier) = [[identifier]]

--- a/test/Nirum/Constructs/ModulePathSpec.hs
+++ b/test/Nirum/Constructs/ModulePathSpec.hs
@@ -3,8 +3,10 @@ module Nirum.Constructs.ModulePathSpec where
 
 import Control.Exception (evaluate)
 import Data.List (sort)
+import Data.Maybe (fromJust)
 import GHC.Exts (IsList (fromList, toList))
 
+import qualified Data.Set as S
 import System.FilePath ((</>))
 import Test.Hspec.Meta
 
@@ -13,6 +15,7 @@ import Nirum.Constructs.ModulePath ( ModulePath (ModuleName, ModulePath)
                                    , ancestors
                                    , fromFilePath
                                    , fromIdentifiers
+                                   , hierarchy
                                    )
 
 spec :: Spec
@@ -82,3 +85,9 @@ spec =
                 fooBarBaz2 `shouldNotSatisfy` (<= fooBarBaz)
                 sort [["abc"], foo, fooBar, fooBarBaz, fooBarBaz2]
                     `shouldBe` [["abc"], foo, fooBar, fooBarBaz, fooBarBaz2]
+        specify "hierarchy" $ do
+            let foo' = fromJust $ fromIdentifiers ["foo", "bar", "baz"]
+            hierarchy foo' `shouldBe` S.fromList [ ["foo", "bar", "baz"]
+                                                 , ["foo", "bar"]
+                                                 , ["foo"]
+                                                 ]


### PR DESCRIPTION
ModulePath를 분리하는 seperateModulePath 함수를 추가합니다. 예를 들어 a.b.c를 가리키는 ModulePath가 있다면, ['a', 'a.b', 'a.b.c'] 형태로 리턴합니다. 자세한 내용은 코드를 참조하세요.

With @AiOO 