### PR TITLE
Upgrade resolver to Stackage Haskell LTS 8.4

### DIFF
--- a/nirum.cabal
+++ b/nirum.cabal
@@ -51,12 +51,12 @@ library
                ,       bytestring
                ,       containers               >=0.5.6.2 && <0.6
                ,       cmdargs                  >=0.10.14 && <0.11
-               ,       directory                >=1.2.5   && <1.3
+               ,       directory                >=1.2.5   && <1.4
                ,       email-validate           >=2.0.0   && <3.0.0
                ,       filepath                 >=1.4     && <1.5
                ,       htoml                    >=1.0.0.0 && <1.1.0.0
                ,       interpolatedstring-perl6 >=1.0.0   && <1.1.0
-               ,       megaparsec               >=5       && <5.2
+               ,       megaparsec               >=5       && <5.3
                ,       mtl                      >=2.2.1   && <3
                ,       parsec
                        -- only for dealing with htoml's ParserError
@@ -118,28 +118,29 @@ test-suite spec
                ,       Util
   default-language:    Haskell2010
   default-extensions:  OverloadedStrings
-  build-depends:       base                     >=4.7     && <5
+  -- omit version specifiers for shared dependencies to library
+  build-depends:       base
                ,       bytestring
-               ,       containers               >=0.5.6.2 && <0.6
+               ,       containers
                ,       directory
-               ,       email-validate           >=2.0.0   && <3.0.0
-               ,       filepath                 >=1.4     && <1.5
+               ,       email-validate
+               ,       filepath
                ,       hspec
                ,       hspec-core
                ,       hspec-meta
-               ,       htoml                    >=1.0.0.0 && <1.1.0.0
-               ,       interpolatedstring-perl6 >=1.0.0   && <1.1.0
-               ,       megaparsec               >=5       && <5.2
-               ,       mtl                      >=2.2.1   && <3
+               ,       htoml
+               ,       interpolatedstring-perl6
+               ,       megaparsec
+               ,       mtl
                ,       nirum
                ,       parsec
                        -- only for dealing with htoml's ParserError
                ,       process                  >=1.1     && <2
                ,       semigroups
-               ,       semver                   >=0.3.0   && <1.0
+               ,       semver
                ,       string-qq                >=0.0.2   && <0.1.0
                ,       temporary                >=1.2     && <1.3
-               ,       text                     >=0.9.1.0 && <1.3
+               ,       text
   ghc-options:         -Wall -Werror
                        -fno-warn-incomplete-uni-patterns
                        -fno-warn-missing-signatures
@@ -150,5 +151,6 @@ test-suite hlint
   hs-source-dirs:      test
   main-is:             HLint.hs
   default-language:    Haskell2010
-  build-depends:       base        >=4.7     && <5
+  -- omit version specifiers for shared dependencies to library
+  build-depends:       base
                ,       hlint       >=1.9     && <2

--- a/src/Nirum/Constructs/Annotation.hs
+++ b/src/Nirum/Constructs/Annotation.hs
@@ -29,8 +29,8 @@ import Nirum.Constructs.Identifier (Identifier)
 docs :: Docs -> Annotation
 docs (Docs d) = Annotation { name = annotationDocsName, metadata = Just d }
 
-data NameDuplication = AnnotationNameDuplication Identifier
-                     deriving (Eq, Ord, Show)
+newtype NameDuplication = AnnotationNameDuplication Identifier
+                          deriving (Eq, Ord, Show)
 
 empty :: AnnotationSet
 empty = AnnotationSet { annotations = M.empty }

--- a/src/Nirum/Constructs/Annotation/Internal.hs
+++ b/src/Nirum/Constructs/Annotation/Internal.hs
@@ -42,7 +42,7 @@ instance Construct Annotation where
 fromTuple :: (Identifier, Maybe Metadata) -> Annotation
 fromTuple (name', meta') = Annotation { name = name', metadata = meta' }
 
-data AnnotationSet
+newtype AnnotationSet
   -- | The set of 'Annotation' values.
   -- Every annotation name has to be unique in the set.
   = AnnotationSet { annotations :: M.Map Identifier (Maybe Metadata) }

--- a/src/Nirum/Constructs/Docs.hs
+++ b/src/Nirum/Constructs/Docs.hs
@@ -17,7 +17,7 @@ annotationDocsName :: Identifier
 annotationDocsName = "docs"
 
 -- | Docstring for constructs.
-data Docs = Docs T.Text deriving (Eq, Ord, Show)
+newtype Docs = Docs T.Text deriving (Eq, Ord, Show)
 
 -- | Convert the docs to text.
 toText :: Docs -> T.Text

--- a/src/Nirum/Constructs/Identifier.hs
+++ b/src/Nirum/Constructs/Identifier.hs
@@ -51,7 +51,7 @@ to @book-category@, and it can be translated to:
 [PascalCase] @BookCategory@
 [lisp-case] @book-category@
 -}
-data Identifier = Identifier T.Text deriving (Show)
+newtype Identifier = Identifier T.Text deriving (Show)
 
 reservedKeywords :: S.Set Identifier
 reservedKeywords = [ "enum"

--- a/src/Nirum/Constructs/Service.hs
+++ b/src/Nirum/Constructs/Service.hs
@@ -91,5 +91,5 @@ instance Declaration Method where
     annotations = methodAnnotations
 
 -- | RPC service.
-data Service =
+newtype Service =
     Service { methods :: DeclarationSet Method } deriving (Eq, Ord, Show)

--- a/src/Nirum/Package/ModuleSet.hs
+++ b/src/Nirum/Package/ModuleSet.hs
@@ -34,7 +34,7 @@ data ImportError = CircularImportError [ModulePath]
                  deriving (Eq, Ord, Show)
 
 -- | The set of 'Module' values.  It can be looked up by its 'ModulePath'.
-data ModuleSet = ModuleSet (M.Map ModulePath Module) deriving (Eq, Ord, Show)
+newtype ModuleSet = ModuleSet (M.Map ModulePath Module) deriving (Eq, Ord, Show)
 
 fromMap :: M.Map ModulePath Module -> Either (S.Set ImportError) ModuleSet
 fromMap ms

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -115,8 +115,8 @@ import Nirum.Package.Metadata ( Author (Author, name, email)
                               )
 import qualified Nirum.Package.ModuleSet as MS
 
-data Python = Python { packageName :: T.Text
-                     } deriving (Eq, Ord, Show, Typeable)
+newtype Python = Python { packageName :: T.Text
+                        } deriving (Eq, Ord, Show, Typeable)
 
 type Package' = Package Python
 type CompileError' = T.Text

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2016-10-10
+resolver: lts-8.4
 flags: {}
 packages:
 - '.'

--- a/test/Nirum/CodeGenSpec.hs
+++ b/test/Nirum/CodeGenSpec.hs
@@ -11,8 +11,7 @@ import Test.Hspec.Meta
 import Nirum.CodeGen (CodeGen, Failure, fromString, runCodeGen)
 
 
-data SampleError = SampleError Text
-    deriving (Eq, Ord, Show)
+newtype SampleError = SampleError Text deriving (Eq, Ord, Show)
 
 instance forall s . Failure s SampleError where
     fromString = return . SampleError . T.pack


### PR DESCRIPTION
As the title says, this patch upgrades `stack`'s resolver from Stackage Nightly an-arbitrary-date something to [LTS Haskell 8.4][1].  Although it's LTS, it's even newer than the previous resolver.

As HLint upgraded, it now suggests all single field record to be `newtype` instead of `data`.  So I followed the suggestion as well.  The most of diffs are caused by this.

Lastly, I removed duplicated version specifiers of the common dependencies between `library` and `test-suite spec`.

[1]: https://www.stackage.org/lts-8.4