### PR TITLE
-t/--target option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ For more infomration, use `--help` option:
 
     Common flags:
       -o --output-dir=DIR   The directory to place object files
+      -t --target=TARGET    The target language.  Available targets: python
       -? --help             Display help message
       -V --version          Print version information
          --numeric-version  Print just the version number

--- a/src/Nirum/Targets.hs
+++ b/src/Nirum/Targets.hs
@@ -11,6 +11,7 @@ module Nirum.Targets ( BuildError (CompileError, PackageError, TargetNameError)
                               )
                      , TargetName
                      , buildPackage
+                     , targetNames
                      ) where
 
 import Data.Either (partitionEithers)
@@ -18,6 +19,7 @@ import Data.Maybe (fromMaybe)
 import Data.Proxy (Proxy)
 
 import Data.ByteString (ByteString)
+import Data.Set (Set)
 import qualified Data.Map.Strict as M
 import Data.Text (Text)
 
@@ -46,6 +48,9 @@ type BuildResult = M.Map FilePath ByteString
 packageBuilders :: M.Map TargetName
                          (FilePath -> IO (Either BuildError BuildResult))
 packageBuilders = M.fromList $(targetProxyMapQ [e|buildPackage'|])
+
+targetNames :: Set TargetName
+targetNames = M.keysSet packageBuilders
 
 buildPackage :: TargetName -> FilePath -> IO (Either BuildError BuildResult)
 buildPackage targetName' =


### PR DESCRIPTION
Although #99 made Nirum's internals possible to extend targets, it didn't expose its extensiblity to the user interface (CLI).

This patch added `-t`/`--target` option to specify the target language of the object. Also it prints the list of all available targets.