### PR TITLE
Use optparse-applicative instead of cmdargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ In order to compile a Nirum package (`examples/`) to a Python package:
 For more infomration, use `--help` option:
 
     $ nirum --help
-    nirum - The IDL compiler and RPC/distributed object framework
+    Nirum: The IDL compiler and RPC/distributed object framework
 
     Usage: nirum [-v|--version] (-o|--output-dir DIR) (-t|--target TARGET) DIR
-      Nirum compiler0.3.0
+      Nirum compiler 0.3.0
 
     Available options:
       -h,--help                Show this help text

--- a/README.md
+++ b/README.md
@@ -55,17 +55,17 @@ In order to compile a Nirum package (`examples/`) to a Python package:
 For more infomration, use `--help` option:
 
     $ nirum --help
-    Nirum Compiler 0.3.0
+    nirum - The IDL compiler and RPC/distributed object framework
 
-    nirum [OPTIONS] DIR
+    Usage: nirum [-v|--version] (-o|--output-dir DIR) (-t|--target TARGET) DIR
+      Nirum compiler0.3.0
 
-    Common flags:
-      -o --output-dir=DIR   The directory to place object files
-      -t --target=TARGET    The target language.  Available targets: python
-      -? --help             Display help message
-      -V --version          Print version information
-         --numeric-version  Print just the version number
-
+    Available options:
+      -h,--help                Show this help text
+      -v,--version             Show version
+      -o,--output-dir DIR      Output directory
+      -t,--target TARGET       Target language name
+      DIR                      Package directory
 
 Building
 --------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,7 @@ after_build:
 test_script:
 - stack test
 # FIXME: duplicate code with test.sh
-- stack exec -- nirum -o nirum_fixture test/nirum_fixture
+- stack exec -- nirum -o nirum_fixture -t python test/nirum_fixture
 - C:\Python35\Scripts\tox
 artifacts:
 - path: nirum-win-x86.exe

--- a/nirum.cabal
+++ b/nirum.cabal
@@ -134,7 +134,6 @@ test-suite spec
                ,       megaparsec
                ,       mtl
                ,       nirum
-               ,       optparse-applicative     >=0.13.1  && <0.14
                ,       parsec
                        -- only for dealing with htoml's ParserError
                ,       process                  >=1.1     && <2

--- a/nirum.cabal
+++ b/nirum.cabal
@@ -58,6 +58,7 @@ library
                ,       interpolatedstring-perl6 >=1.0.0   && <1.1.0
                ,       megaparsec               >=5       && <5.3
                ,       mtl                      >=2.2.1   && <3
+               ,       optparse-applicative     >=0.13.1  && <0.14
                ,       parsec
                        -- only for dealing with htoml's ParserError
                ,       semver                   >=0.3.0   && <1.0
@@ -133,6 +134,7 @@ test-suite spec
                ,       megaparsec
                ,       mtl
                ,       nirum
+               ,       optparse-applicative     >=0.13.1  && <0.14
                ,       parsec
                        -- only for dealing with htoml's ParserError
                ,       process                  >=1.1     && <2

--- a/src/Nirum/Cli.hs
+++ b/src/Nirum/Cli.hs
@@ -168,10 +168,10 @@ main = do
         OPT.info
             (OPT.helper <*> versionOption <*> programOptions)
             (OPT.fullDesc <>
-             OPT.progDesc ("Nirum compiler" ++ versionString) <>
+             OPT.progDesc ("Nirum compiler " ++ versionString) <>
              OPT.header header)
     header :: String
-    header = "nirum - The IDL compiler and RPC/distributed object framework"
+    header = "Nirum: The IDL compiler and RPC/distributed object framework"
     versionOption :: OPT.Parser (Opts -> Opts)
     versionOption = OPT.infoOption
         versionString (OPT.long "version" <>

--- a/src/Nirum/Cli.hs
+++ b/src/Nirum/Cli.hs
@@ -8,7 +8,7 @@ import qualified Data.ByteString as B
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import qualified Data.Text as T
-import Data.Monoid
+import Data.Monoid ((<>))
 import qualified Options.Applicative as OPT
 import System.Directory (createDirectoryIfMissing)
 import System.Exit (die)

--- a/src/Nirum/Cli.hs
+++ b/src/Nirum/Cli.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ExtendedDefaultRules, QuasiQuotes, DeriveDataTypeable #-}
+{-# LANGUAGE ExtendedDefaultRules, QuasiQuotes #-}
 module Nirum.Cli (main, writeFiles) where
 
 import Control.Monad (forM_)

--- a/src/Nirum/Cli.hs
+++ b/src/Nirum/Cli.hs
@@ -167,7 +167,8 @@ main = do
     optsParser =
         OPT.info
             (OPT.helper <*> versionOption <*> programOptions)
-            (OPT.fullDesc <> OPT.progDesc "Nirum compiler." <>
+            (OPT.fullDesc <>
+             OPT.progDesc ("Nirum compiler" ++ versionString) <>
              OPT.header header)
     header :: String
     header = "nirum - The IDL compiler and RPC/distributed object framework"
@@ -178,10 +179,10 @@ main = do
     programOptions :: OPT.Parser Opts
     programOptions =
         Opts <$> OPT.strOption
-            (OPT.long "outdir" <> OPT.short 'o' <> OPT.metavar "OUTDIR" <>
-             OPT.help "out directory") <*>
+            (OPT.long "output-dir" <> OPT.short 'o' <> OPT.metavar "DIR" <>
+             OPT.help "Output directory") <*>
         OPT.strOption
             (OPT.long "target" <> OPT.short 't' <> OPT.metavar "TARGET" <>
-             OPT.help "Target name") <*>
+             OPT.help "Target language name") <*>
         OPT.strArgument
-            (OPT.metavar "PACKAGE" <> OPT.help "Package directory")
+            (OPT.metavar "DIR" <> OPT.help "Package directory")

--- a/test.sh
+++ b/test.sh
@@ -2,6 +2,6 @@
 set -e
 
 stack build
-stack exec -- nirum -o nirum_fixture test/nirum_fixture
+stack exec -- nirum -o nirum_fixture -t python test/nirum_fixture
 
 tox --skip-missing-interpreters


### PR DESCRIPTION
Use [optparse-applicative](https://haskell-lang.org/library/optparse-applicative) which one is suggested in #88. this PR close #88 as well.