### PR TITLE
Fix regressive things PR #111 missed

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Getting started
 In order to compile a Nirum package (`examples/`) to a Python package:
 
     $ mkdir out/  # directory to place generated Python files
-    $ nirum -o out/ examples/
+    $ nirum -t python -o out/ examples/
 
 For more infomration, use `--help` option:
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ For more infomration, use `--help` option:
       -h,--help                Show this help text
       -v,--version             Show version
       -o,--output-dir DIR      Output directory
-      -t,--target TARGET       Target language name
+      -t,--target TARGET       Target language name. Available: docs, python
       DIR                      Package directory
 
 Building

--- a/nirum.cabal
+++ b/nirum.cabal
@@ -56,7 +56,6 @@ library
                ,       bytestring
                ,       cmark                    >=0.5     && <0.6
                ,       containers               >=0.5.6.2 && <0.6
-               ,       cmdargs                  >=0.10.14 && <0.11
                ,       directory                >=1.2.5   && <1.4
                ,       email-validate           >=2.0.0   && <3.0.0
                ,       filepath                 >=1.4     && <1.5

--- a/src/Nirum/Cli.hs
+++ b/src/Nirum/Cli.hs
@@ -183,6 +183,7 @@ main = do
              OPT.help "Output directory") <*>
         OPT.strOption
             (OPT.long "target" <> OPT.short 't' <> OPT.metavar "TARGET" <>
-             OPT.help "Target language name") <*>
+             OPT.help [qq|Target language name.
+                          Available: $targetNamesText|]) <*>
         OPT.strArgument
             (OPT.metavar "DIR" <> OPT.help "Package directory")


### PR DESCRIPTION
Fixed several things that PR #111 missed:

- Remove cmdargs from `build-depends` as it's no more used since #111 introduced optparse-applicative.
- Update the CLI example on README.md as `-t`/`--target` became required.
- Restore the list of available targets on `-h`/`--help`.