### PR TITLE
Fix missing `import typing` on Python 2

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -2,6 +2,8 @@
 set -e
 
 stack build
-stack exec -- nirum -o nirum_fixture -t python test/nirum_fixture
+python_outdir="nirum_fixture"
+stack exec -- nirum -o "$python_outdir" -t python test/nirum_fixture
+echo "*" > "$python_outdir/.gitignore"
 
 tox --skip-missing-interpreters

--- a/test/Nirum/Targets/PythonSpec.hs
+++ b/test/Nirum/Targets/PythonSpec.hs
@@ -168,7 +168,7 @@ spec = parallel $ forM_ versions $ \ (ver, typing) -> do
             localImports ctx2 `shouldBe` []
             compileError codeGen2 `shouldBe` Nothing
 
-    specify "compilePrimitiveType" $ do
+    specify [qq|compilePrimitiveType ($ver)|] $ do
         code (compilePrimitiveType Bool) `shouldBe` "bool"
         code (compilePrimitiveType Bigint) `shouldBe` "int"
         let (decimalCode, decimalContext) = run' (compilePrimitiveType Decimal)
@@ -201,7 +201,7 @@ spec = parallel $ forM_ versions $ \ (ver, typing) -> do
                 Python2 -> "unicode"
                 Python3 -> "str"
 
-    describe "compileTypeExpression" $ do
+    describe [qq|compileTypeExpression ($ver)|] $ do
         let s = makeDummySource $ Module [] Nothing
         specify "TypeIdentifier" $ do
             let (c, ctx) = run' $
@@ -234,7 +234,7 @@ spec = parallel $ forM_ versions $ \ (ver, typing) -> do
             localImports ctx'''' `shouldBe` []
             c'''' `shouldBe` Right "typing.Mapping[uuid.UUID, int]"
 
-    describe "toClassName" $ do
+    describe [qq|toClassName ($ver)|] $ do
         it "transform the facial name of the argument into PascalCase" $ do
             toClassName "test" `shouldBe` "Test"
             toClassName "hello-world" `shouldBe` "HelloWorld"
@@ -243,7 +243,7 @@ spec = parallel $ forM_ versions $ \ (ver, typing) -> do
             toClassName "false" `shouldBe` "False_"
             toClassName "none" `shouldBe` "None_"
 
-    describe "toAttributeName" $ do
+    describe [qq|toAttributeName ($ver)|] $ do
         it "transform the facial name of the argument into snake_case" $ do
             toAttributeName "test" `shouldBe` "test"
             toAttributeName "hello-world" `shouldBe` "hello_world"
@@ -252,7 +252,7 @@ spec = parallel $ forM_ versions $ \ (ver, typing) -> do
             toAttributeName "lambda" `shouldBe` "lambda_"
             toAttributeName "nonlocal" `shouldBe` "nonlocal_"
 
-    describe "toNamePair" $ do
+    describe [qq|toNamePair ($ver)|] $ do
         it "transforms the name to a Python code string of facial/behind pair" $
             do toNamePair "text" `shouldBe` "('text', 'text')"
                toNamePair (Name "test" "hello") `shouldBe` "('test', 'hello')"
@@ -266,7 +266,7 @@ spec = parallel $ forM_ versions $ \ (ver, typing) -> do
             toNamePair (Name "abc" "lambda") `shouldBe` "('abc', 'lambda')"
             toNamePair (Name "lambda" "abc") `shouldBe` "('lambda_', 'abc')"
 
-    specify "stringLiteral" $ do
+    specify [qq|stringLiteral ($ver)|] $ do
         stringLiteral "asdf" `shouldBe` [q|"asdf"|]
         stringLiteral [q|Say 'hello world'|]
             `shouldBe` [q|"Say 'hello world'"|]
@@ -275,7 +275,7 @@ spec = parallel $ forM_ versions $ \ (ver, typing) -> do
         stringLiteral "Say '\xc548\xb155'"
             `shouldBe` [q|u"Say '\uc548\ub155'"|]
 
-    describe "compilePackage" $ do
+    describe [qq|compilePackage ($ver)|] $ do
         it "returns a Map of file paths and their contents to generate" $ do
             let (Source pkg _) = makeDummySource $ Module [] Nothing
                 files = compilePackage pkg
@@ -307,7 +307,7 @@ spec = parallel $ forM_ versions $ \ (ver, typing) -> do
                     ]
             M.keysSet files `shouldBe` directoryStructure
 
-    describe "InstallRequires" $ do
+    describe [qq|InstallRequires ($ver)|] $ do
         let req = InstallRequires [] []
             req2 = req { dependencies = ["six"] }
             req3 = req { optionalDependencies = [((3, 4), ["enum34"])] }
@@ -350,9 +350,9 @@ spec = parallel $ forM_ versions $ \ (ver, typing) -> do
                                              (3, 4) "ipaddress"
             (req4 `unionInstallRequires` req5) `shouldBe` req6
             (req5 `unionInstallRequires` req4) `shouldBe` req6
-    specify "toImportPath" $
+    specify [qq|toImportPath ($ver)|] $
         PY.toImportPath ["foo", "bar"] `shouldBe` "foo.bar"
-    describe "Add ancestors of packages" $ do
+    describe [qq|add ancestors of packages ($ver)|] $ do
         let (Source pkg _) = makeDummySource $ Module [] Nothing
             modulePaths = MS.keysSet $ modules pkg
         specify "toImportPaths" $

--- a/test/nirum_fixture/fixture/foo.nrm
+++ b/test/nirum_fixture/fixture/foo.nrm
@@ -33,6 +33,11 @@ record line (
     bigint length,
 );
 
+record import-typing (
+    // see also: https://github.com/spoqa/nirum/issues/93
+    bigint? an-optional-field,
+);
+
 union mixed-name = western-name ( text first-name
                                 , text middle-name
                                 , text last-name


### PR DESCRIPTION
There was a bug that Python 2 code generator had missed `import typing` even if some type expressions require it.  This patch fixed the bug #93.