### PR TITLE
Add "minimum_runtime" option to Python target settings

### DIFF
--- a/examples/package.toml
+++ b/examples/package.toml
@@ -2,3 +2,4 @@ version = "0.3.0"
 
 [targets.python]
 name = "nirum-examples"
+minimum_runtime = "0.3.9"

--- a/src/Nirum/Package/Metadata.hs
+++ b/src/Nirum/Package/Metadata.hs
@@ -39,6 +39,7 @@ module Nirum.Package.Metadata ( Author (Author, email, name, uri)
                               , readMetadata
                               , stringField
                               , tableField
+                              , versionField
                               ) where
 
 import Data.Proxy (Proxy (Proxy))

--- a/test/Nirum/PackageSpec.hs
+++ b/test/Nirum/PackageSpec.hs
@@ -45,7 +45,7 @@ import Nirum.Package.ModuleSet ( ImportError (MissingModulePathError)
                                )
 import Nirum.Package.ModuleSetSpec (validModules)
 import Nirum.Parser (parseFile)
-import Nirum.Targets.Python (Python (Python))
+import Nirum.Targets.Python (Python (Python), minimumRuntime)
 
 createPackage :: Metadata t -> [(ModulePath, Module)] -> Package t
 createPackage metadata' modules' =
@@ -61,7 +61,7 @@ createValidPackage t = createPackage Metadata { version = SV.initial
 
 spec :: Spec
 spec = do
-    testPackage (Python "nirum-examples")
+    testPackage (Python "nirum-examples" minimumRuntime)
     testPackage DummyTarget
 
 testPackage :: forall t . Target t => t -> Spec

--- a/test/Nirum/Targets/PythonSpec.hs
+++ b/test/Nirum/Targets/PythonSpec.hs
@@ -59,16 +59,16 @@ import Nirum.Targets.Python ( Source (Source)
                             , addOptionalDependency
                             , compilePrimitiveType
                             , compileTypeExpression
+                            , insertLocalImport
+                            , insertStandardImport
+                            , insertThirdPartyImports
                             , minimumRuntime
+                            , runCodeGen
                             , stringLiteral
                             , toAttributeName
                             , toClassName
                             , toNamePair
                             , unionInstallRequires
-                            , insertLocalImport
-                            , insertStandardImport
-                            , insertThirdPartyImports
-                            , runCodeGen
                             )
 
 codeGen :: a -> CodeGen a

--- a/test/Nirum/Targets/PythonSpec.hs
+++ b/test/Nirum/Targets/PythonSpec.hs
@@ -59,6 +59,7 @@ import Nirum.Targets.Python ( Source (Source)
                             , addOptionalDependency
                             , compilePrimitiveType
                             , compileTypeExpression
+                            , minimumRuntime
                             , stringLiteral
                             , toAttributeName
                             , toClassName
@@ -89,7 +90,7 @@ makeDummySource' pathPrefix m =
                     , uri = Nothing
                     }
               ]
-        , target = Python "sample-package"
+        , target = Python "sample-package" minimumRuntime
         }
     pkg :: Package Python
     pkg = createPackage


### PR DESCRIPTION
This patch adds `minimum_runtime` option to Python target settings. The specified version goes to the generated `install_requires` list. Also the Nirum compiler now has its own minimum runtime version; see also `Nirum.Targets.Python.minimumRuntime` constant.

If `minimum_runtime` option specified by package.toml is older than compiler's minimum runtime version, or it's omitted, compiler's version is used instead.

Closes #118.