### PR TITLE
Add renames option to Python target

### DIFF
--- a/docs/target/python.md
+++ b/docs/target/python.md
@@ -48,3 +48,44 @@ script.
 
 [nirum]: https://pypi.python.org/pypi/nirum
 [semver]: http://semver.org/
+
+
+### `renames`: Rename module paths
+
+Sometimes you may need to use other name in Python than package names defined
+by Nirum IDL.  For example, you may choose a general term `statistics` for
+a module name, but need to use an other name in Python since it's reserved
+by Python standard library.  In case, `renames` configuration replace package
+names when it's compiled to Python.
+
+It's a table of strings where keys are module paths to be replaced and
+values are module paths to replace with.  Note that keys and values are
+not Python import paths but Nirum IDL module paths.  That means you can't use
+names like `__foo__` because Nirum IDL doesn't allow more than twice continued
+underscores/hyphens.
+
+The following example replaces `statistics` to `rpc.statistics`:
+
+~~~~~~~~ toml
+[targets.python.renames]
+statistics = "rpc.statistics"
+~~~~~~~~
+
+The `renames` table is recursively applied to submodules.  If you have 4 modules
+and submodules like `statistics`, `statistics.products`, `statistics.users`, and
+`statistics.users.friends`, they are renamed to `rpc.statistics.products`,
+`rpc.statistics`, `rpc.statistics.products`, `rpc.statistics.users`, and
+`rpc.statistics.users.friends`.
+
+Though it's applied only from root modules to submodules.  Even if there're
+some matched module paths in the middle they aren't renamed.  For example,
+whereas `statistics.foo` is renamed to `rpc.statistics.foo`, `foo.statistics`
+is remained without renaming.
+
+Names to be replaced can contain periods.  For example, the following example
+renames `foo.bar.baz` to `new-name.baz`:
+
+~~~~~~~~ toml
+[targets.python.renames]
+"foo.bar" = "new-name"  # Note that the key is quoted.
+~~~~~~~~

--- a/docs/target/python.md
+++ b/docs/target/python.md
@@ -1,0 +1,50 @@
+Python target
+=============
+
+Python is Nirum's most actively maintained target language.  If you want to
+evaluate Nirum's every feature Python would be the best choice.
+
+
+Settings
+--------
+
+Nirum's Python target provides its own settings.  The below settings can be
+configured in package.toml's `targets.python.*` fields.
+
+
+### `name` (required): PyPI distribution name
+
+Whereas Nirum packages don't have a package name, generated Python packages
+need its own unique name.  They are called by several terms: package name,
+distribution name, PyPI handle, etc.  It's used to refer the package to
+install in `pip install` command, and placed following
+<https://pypi.python.org/pypi/> URL.
+
+~~~~~~~~ toml
+# Example
+[targets.python]
+name = "py-foobar"  # will be submitted to: pypi.python.org/pypi/py-foobar
+~~~~~~~~
+
+
+### `minimum_runtime`: Ensure Python runtime library's minimum version
+
+Generated Python object code depends on Python [nirum][] package, the runtime
+library for Nirum.  As it's separately distributed, you might face with subtle
+incompatibilities between versions.  In order to prevent such incompatibilities
+by ensuring the minimum version, Python target provides a `minimum_runtime`
+option.  It takes a version string of [nirum][] package which follows [Semantic
+Versioning][semver].
+
+~~~~~~~~ toml
+# Example
+[targets.python]
+name = "py-foobar"
+minimum_runtime = "0.3.9"  # requires nirum >= 0.3.9
+~~~~~~~~
+
+The configured version specifier goes to `install_requires` list of setup.py
+script.
+
+[nirum]: https://pypi.python.org/pypi/nirum
+[semver]: http://semver.org/

--- a/nirum.cabal
+++ b/nirum.cabal
@@ -151,6 +151,7 @@ test-suite spec
                ,       string-qq                >=0.0.2   && <0.1.0
                ,       temporary                >=1.2     && <1.3
                ,       text
+               ,       unordered-containers
   ghc-options:         -Wall -Werror
                        -fno-warn-incomplete-uni-patterns
                        -fno-warn-missing-signatures

--- a/src/Nirum/Constructs/ModulePath.hs
+++ b/src/Nirum/Constructs/ModulePath.hs
@@ -8,6 +8,7 @@ module Nirum.Constructs.ModulePath ( ModulePath ( ModuleName
                                    , fromIdentifiers
                                    , hierarchy
                                    , hierarchies
+                                   , replacePrefix
                                    ) where
 
 import Data.Char (toLower)
@@ -59,6 +60,14 @@ fromFilePath filePath =
 hierarchy :: ModulePath -> S.Set ModulePath
 hierarchy m@ModuleName {} = S.singleton m
 hierarchy m@(ModulePath parent _) = m `S.insert` hierarchy parent
+
+replacePrefix :: ModulePath -> ModulePath -> ModulePath -> ModulePath
+replacePrefix from to path'
+ | path' == from = to
+ | otherwise = case path' of
+                   ModuleName {} -> path'
+                   ModulePath p n -> ModulePath (replacePrefix from to p) n
+
 
 instance IsList ModulePath where
     type Item ModulePath = Identifier

--- a/src/Nirum/Constructs/ModulePath.hs
+++ b/src/Nirum/Constructs/ModulePath.hs
@@ -61,6 +61,9 @@ hierarchy :: ModulePath -> S.Set ModulePath
 hierarchy m@ModuleName {} = S.singleton m
 hierarchy m@(ModulePath parent _) = m `S.insert` hierarchy parent
 
+hierarchies :: S.Set ModulePath -> S.Set ModulePath
+hierarchies modulePaths = S.unions $ toList $ S.map hierarchy modulePaths
+
 replacePrefix :: ModulePath -> ModulePath -> ModulePath -> ModulePath
 replacePrefix from to path'
  | path' == from = to
@@ -76,6 +79,3 @@ instance IsList ModulePath where
                   (fromIdentifiers identifiers)
     toList (ModuleName identifier) = [identifier]
     toList (ModulePath path' identifier) = toList path' ++ [identifier]
-
-hierarchies :: S.Set ModulePath -> S.Set ModulePath
-hierarchies modulePaths = S.unions $ toList $ S.map hierarchy modulePaths

--- a/src/Nirum/Package/Metadata.hs
+++ b/src/Nirum/Package/Metadata.hs
@@ -30,6 +30,7 @@ module Nirum.Package.Metadata ( Author (Author, email, name, uri)
                                        )
                               , TargetName
                               , VTArray
+                              , fieldType
                               , metadataFilename
                               , metadataPath
                               , parseMetadata
@@ -202,18 +203,19 @@ readFromPackage :: Target t
                 => FilePath -> IO (Either MetadataError (Metadata t))
 readFromPackage = readMetadata . metadataPath
 
-printNode :: Node -> MetadataFieldType
-printNode (VTable t) = if length t == 1
+-- | Show the typename of the given 'Node'.
+fieldType :: Node -> MetadataFieldType
+fieldType (VTable t) = if length t == 1
                        then "table of an item"
                        else [qq|table of {length t} items|]
-printNode (VTArray a) = [qq|array of {length a} tables|]
-printNode (VString s) = [qq|string ($s)|]
-printNode (VInteger i) = [qq|integer ($i)|]
-printNode (VFloat f) = [qq|float ($f)|]
-printNode (VBoolean True) = "boolean (true)"
-printNode (VBoolean False) = "boolean (false)"
-printNode (VDatetime d) = [qq|datetime ($d)|]
-printNode (VArray a) = [qq|array of {length a} values|]
+fieldType (VTArray a) = [qq|array of {length a} tables|]
+fieldType (VString s) = [qq|string ($s)|]
+fieldType (VInteger i) = [qq|integer ($i)|]
+fieldType (VFloat f) = [qq|float ($f)|]
+fieldType (VBoolean True) = "boolean (true)"
+fieldType (VBoolean False) = "boolean (false)"
+fieldType (VDatetime d) = [qq|datetime ($d)|]
+fieldType (VArray a) = [qq|array of {length a} values|]
 
 field :: MetadataField -> Table -> Either MetadataError Node
 field field' table =
@@ -230,7 +232,7 @@ typedField typename match field' table = do
     node <- field field' table
     case match node of
         Just value -> return value
-        Nothing -> Left $ FieldTypeError field' typename $ printNode node
+        Nothing -> Left $ FieldTypeError field' typename $ fieldType node
 
 optional :: Either MetadataError a -> Either MetadataError (Maybe a)
 optional (Right value) = Right $ Just value

--- a/src/Nirum/Package/Metadata.hs
+++ b/src/Nirum/Package/Metadata.hs
@@ -215,7 +215,9 @@ fieldType (VFloat f) = [qq|float ($f)|]
 fieldType (VBoolean True) = "boolean (true)"
 fieldType (VBoolean False) = "boolean (false)"
 fieldType (VDatetime d) = [qq|datetime ($d)|]
-fieldType (VArray a) = [qq|array of {length a} values|]
+fieldType (VArray a) = if length a == 1
+                       then "array of a value"
+                       else [qq|array of {length a} values|]
 
 field :: MetadataField -> Table -> Either MetadataError Node
 field field' table =

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -31,6 +31,7 @@ module Nirum.Targets.Python ( Code
                             , insertStandardImport
                             , insertThirdPartyImports
                             , minimumRuntime
+                            , parseModulePath
                             , runCodeGen
                             , stringLiteral
                             , toAttributeName
@@ -61,7 +62,11 @@ import qualified Nirum.CodeGen as C
 import Nirum.CodeGen (Failure)
 import qualified Nirum.Constructs.DeclarationSet as DS
 import qualified Nirum.Constructs.Identifier as I
-import Nirum.Constructs.ModulePath (ModulePath, hierarchy, hierarchies)
+import Nirum.Constructs.ModulePath ( ModulePath
+                                   , fromIdentifiers
+                                   , hierarchy
+                                   , hierarchies
+                                   )
 import Nirum.Constructs.Name (Name (Name))
 import qualified Nirum.Constructs.Name as N
 import Nirum.Constructs.Service ( Method ( Method
@@ -995,6 +1000,13 @@ compilePackage' package =
     installRequires = foldl unionInstallRequires
                             (InstallRequires [] [])
                             [deps | (_, Right (deps, _)) <- modules']
+
+parseModulePath :: T.Text -> Maybe ModulePath
+parseModulePath string =
+    mapM I.fromText identTexts >>= fromIdentifiers
+  where
+    identTexts :: [T.Text]
+    identTexts = T.split (== '.') string
 
 instance Target Python where
     type CompileResult Python = Code

--- a/test/Nirum/Constructs/ModulePathSpec.hs
+++ b/test/Nirum/Constructs/ModulePathSpec.hs
@@ -14,6 +14,7 @@ import Nirum.Constructs.ModulePath ( ModulePath (ModuleName, ModulePath)
                                    , hierarchies
                                    , fromFilePath
                                    , fromIdentifiers
+                                   , replacePrefix
                                    )
 
 spec :: Spec
@@ -61,6 +62,25 @@ spec =
                 , ["tar"]
                 , ["tar", "gz"]
                 ]
+        specify "replacePrefix" $ do
+            replacePrefix ["foo"] ["qux"] ["foo"] `shouldBe` ["qux"]
+            replacePrefix ["foo"] ["qux"] ["foo", "bar"] `shouldBe`
+                ["qux", "bar"]
+            replacePrefix ["foo"] ["qux"] ["bar", "foo"] `shouldBe`
+                ["bar", "foo"]
+            replacePrefix ["foo"] ["qux", "quz"] ["foo"] `shouldBe`
+                ["qux", "quz"]
+            replacePrefix ["foo"] ["qux", "quz"] ["foo", "bar"] `shouldBe`
+                ["qux", "quz", "bar"]
+            replacePrefix ["foo"] ["qux", "quz"] ["bar", "foo"] `shouldBe`
+                ["bar", "foo"]
+            replacePrefix ["foo", "bar"] ["qux"] ["foo"] `shouldBe` ["foo"]
+            replacePrefix ["foo", "bar"] ["qux"] ["foo", "bar"] `shouldBe`
+                ["qux"]
+            replacePrefix ["foo", "bar"] ["qux"] ["foo", "bar", "baz"]
+                `shouldBe` ["qux", "baz"]
+            replacePrefix ["foo", "bar"] ["qux"] ["bar", "foo"] `shouldBe`
+                ["bar", "foo"]
         context "Construct" $
             specify "toCode" $ do
                 toCode foo `shouldBe` "foo"

--- a/test/Nirum/Package/MetadataSpec.hs
+++ b/test/Nirum/Package/MetadataSpec.hs
@@ -4,7 +4,9 @@ module Nirum.Package.MetadataSpec where
 import Control.Monad (forM_)
 import Data.Char (isSpace)
 import Data.Either (isRight)
+import Data.Maybe (fromJust)
 
+import qualified Data.HashMap.Strict as HM
 import qualified Data.Map.Strict as M
 import qualified Data.SemVer as SV
 import Data.Text (Text)
@@ -30,6 +32,7 @@ import Nirum.Package.Metadata ( Metadata (Metadata, version)
                                        , targetName
                                        , toByteString
                                        )
+                              , fieldType
                               , metadataFilename
                               , metadataPath
                               , parseMetadata
@@ -190,6 +193,40 @@ spec =
                 Left (FieldTypeError "d" "string" "float (1.0)")
             versionField "e" table `shouldBe` Left (FieldValueError "e"
                 "expected a semver string (e.g. \"1.2.3\"), not \"1.2.3.4\"")
+        specify "fieldType" $ do
+            let Right table = parseTomlDoc "<string>"
+                    [q|s = "foobar"
+                       i = 123
+                       f = 3.14
+                       bt = true
+                       bf = false
+                       d = 2017-03-16T10:56:30Z
+                       a0 = []
+                       a3 = ["foo", "bar", "baz"]
+                       t0 = {}
+                       t1 = { a = 1 }
+                       [t2]
+                       a = 1
+                       b = 2
+                       [[ta]]
+                       a = 1
+                       b = 2
+                       [[ta]]
+                       c = 3
+                       d = 4|]
+                get = fromJust . (`HM.lookup` table)
+            fieldType (get "s") `shouldBe` "string (foobar)"
+            fieldType (get "i") `shouldBe` "integer (123)"
+            fieldType (get "f") `shouldBe` "float (3.14)"
+            fieldType (get "bt") `shouldBe` "boolean (true)"
+            fieldType (get "bf") `shouldBe` "boolean (false)"
+            fieldType (get "d") `shouldBe` "datetime (2017-03-16 10:56:30 UTC)"
+            fieldType (get "a0") `shouldBe` "array of 0 values"
+            fieldType (get "a3") `shouldBe` "array of 3 values"
+            fieldType (get "t0") `shouldBe` "table of 0 items"
+            fieldType (get "t1") `shouldBe` "table of an item"
+            fieldType (get "t2") `shouldBe` "table of 2 items"
+            fieldType (get "ta") `shouldBe` "array of 2 tables"
   where
     parse :: Text -> Either MetadataError (Metadata DummyTarget)
     parse = parseMetadata "<string>"

--- a/test/Nirum/Package/MetadataSpec.hs
+++ b/test/Nirum/Package/MetadataSpec.hs
@@ -202,6 +202,7 @@ spec =
                        bf = false
                        d = 2017-03-16T10:56:30Z
                        a0 = []
+                       a1 = ["foobar"]
                        a3 = ["foo", "bar", "baz"]
                        t0 = {}
                        t1 = { a = 1 }
@@ -222,6 +223,7 @@ spec =
             fieldType (get "bf") `shouldBe` "boolean (false)"
             fieldType (get "d") `shouldBe` "datetime (2017-03-16 10:56:30 UTC)"
             fieldType (get "a0") `shouldBe` "array of 0 values"
+            fieldType (get "a1") `shouldBe` "array of a value"
             fieldType (get "a3") `shouldBe` "array of 3 values"
             fieldType (get "t0") `shouldBe` "table of 0 items"
             fieldType (get "t1") `shouldBe` "table of an item"

--- a/test/Nirum/PackageSpec.hs
+++ b/test/Nirum/PackageSpec.hs
@@ -61,7 +61,7 @@ createValidPackage t = createPackage Metadata { version = SV.initial
 
 spec :: Spec
 spec = do
-    testPackage (Python "nirum-examples" minimumRuntime)
+    testPackage (Python "nirum-examples" minimumRuntime [])
     testPackage DummyTarget
 
 testPackage :: forall t . Target t => t -> Spec

--- a/test/Nirum/Targets/PythonSpec.hs
+++ b/test/Nirum/Targets/PythonSpec.hs
@@ -63,6 +63,7 @@ import Nirum.Targets.Python ( Source (Source)
                             , insertStandardImport
                             , insertThirdPartyImports
                             , minimumRuntime
+                            , parseModulePath
                             , runCodeGen
                             , stringLiteral
                             , toAttributeName
@@ -354,6 +355,18 @@ spec = parallel $ forM_ ([Python2, Python3] :: [PythonVersion]) $ \ ver -> do
                                                     , "foo.bar"
                                                     , "qux"
                                                     ]
+    specify "parseModulePath" $ do
+        parseModulePath "" `shouldBe` Nothing
+        parseModulePath "foo" `shouldBe` Just ["foo"]
+        parseModulePath "foo.bar" `shouldBe` Just ["foo", "bar"]
+        parseModulePath "foo.bar-baz" `shouldBe` Just ["foo", "bar-baz"]
+        parseModulePath "foo." `shouldBe` Nothing
+        parseModulePath "foo.bar." `shouldBe` Nothing
+        parseModulePath ".foo" `shouldBe` Nothing
+        parseModulePath ".foo.bar" `shouldBe` Nothing
+        parseModulePath "foo..bar" `shouldBe` Nothing
+        parseModulePath "foo.bar>" `shouldBe` Nothing
+        parseModulePath "foo.bar-" `shouldBe` Nothing
 
 
 {-# ANN module ("HLint: ignore Functor law" :: String) #-}

--- a/test/Nirum/Targets/PythonSpec.hs
+++ b/test/Nirum/Targets/PythonSpec.hs
@@ -55,6 +55,7 @@ import Nirum.Targets.Python ( Source (Source)
                                               )
                             , Python (Python)
                             , PythonVersion (Python2, Python3)
+                            , RenameMap
                             , addDependency
                             , addOptionalDependency
                             , compilePrimitiveType
@@ -64,6 +65,7 @@ import Nirum.Targets.Python ( Source (Source)
                             , insertThirdPartyImports
                             , minimumRuntime
                             , parseModulePath
+                            , renameModulePath
                             , runCodeGen
                             , stringLiteral
                             , toAttributeName
@@ -367,3 +369,15 @@ spec = parallel $ forM_ ([Python2, Python3] :: [PythonVersion]) $ \ ver -> do
         parseModulePath "foo..bar" `shouldBe` Nothing
         parseModulePath "foo.bar>" `shouldBe` Nothing
         parseModulePath "foo.bar-" `shouldBe` Nothing
+    specify "renameModulePath" $ do
+        let renames = [ (["foo"], ["poo"])
+                      , (["foo", "bar"], ["foo"])
+                      , (["baz"], ["p", "az"])
+                      ] :: RenameMap
+        renameModulePath renames ["foo"] `shouldBe` ["poo"]
+        renameModulePath renames ["foo", "baz"] `shouldBe` ["poo", "baz"]
+        renameModulePath renames ["foo", "bar"] `shouldBe` ["foo"]
+        renameModulePath renames ["foo", "bar", "qux"] `shouldBe` ["foo", "qux"]
+        renameModulePath renames ["baz"] `shouldBe` ["p", "az"]
+        renameModulePath renames ["baz", "qux"] `shouldBe` ["p", "az", "qux"]
+        renameModulePath renames ["qux", "foo"] `shouldBe` ["qux", "foo"]

--- a/test/Nirum/Targets/PythonSpec.hs
+++ b/test/Nirum/Targets/PythonSpec.hs
@@ -367,9 +367,3 @@ spec = parallel $ forM_ ([Python2, Python3] :: [PythonVersion]) $ \ ver -> do
         parseModulePath "foo..bar" `shouldBe` Nothing
         parseModulePath "foo.bar>" `shouldBe` Nothing
         parseModulePath "foo.bar-" `shouldBe` Nothing
-
-
-{-# ANN module ("HLint: ignore Functor law" :: String) #-}
-{-# ANN module ("HLint: ignore Monad law, left identity" :: String) #-}
-{-# ANN module ("HLint: ignore Monad law, right identity" :: String) #-}
-{-# ANN module ("HLint: ignore Use >=>" :: String) #-}

--- a/test/nirum_fixture/package.toml
+++ b/test/nirum_fixture/package.toml
@@ -7,3 +7,5 @@ email = "dev@nirum.org"
 [targets]
 [targets.python]
 name = "nirum_fixture"
+[targets.python.renames]
+"renames.test" = "renamed"

--- a/test/nirum_fixture/renames/test/foo.nrm
+++ b/test/nirum_fixture/renames/test/foo.nrm
@@ -1,0 +1,3 @@
+import renames.test.foo.bar (bar-test);
+
+record foo-test (bar-test a);

--- a/test/nirum_fixture/renames/test/foo/bar.nrm
+++ b/test/nirum_fixture/renames/test/foo/bar.nrm
@@ -1,0 +1,1 @@
+unboxed bar-test (text);

--- a/test/python/renames_test.py
+++ b/test/python/renames_test.py
@@ -1,0 +1,6 @@
+from renamed.foo import FooTest
+from renamed.foo.bar import BarTest
+
+
+def test_imports_are_renamed():
+    assert FooTest.__nirum_field_types__['a'] is BarTest

--- a/test/python/setup_test.py
+++ b/test/python/setup_test.py
@@ -18,5 +18,6 @@ def test_setup_metadata():
     assert ['nirum'] == pkg['Requires']
     assert set(pkg['Provides']) == {
         'fixture', 'fixture.foo', 'fixture.foo.bar', 'fixture.qux',
+        'renamed', 'renamed.foo', 'renamed.foo.bar',
     }
     assert ['0.3.0'] == pkg['Version']


### PR DESCRIPTION
This patch introduces a new option `targets.python.renames`.  It is a translation table of `ModulePath` to `ModulePath` and purposes to rename the matched module paths.  Here's an example (which motivated me to implement this):

```toml
[targets.python.names]
contract = "contract-schema"
```

It makes the root module `contract` to be compiled to Python package `contract_schema`.  See docs/target/python.md for more details.