### PR TITLE
Convert mutable type which is unhasable to immutable types

### DIFF
--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -303,8 +303,8 @@ toIndentedCodes f traversable concatenator =
     T.intercalate concatenator $ map f traversable
 
 compileParameters :: (ParameterName -> ParameterType -> Code)
-               -> [(T.Text, Code)]
-               -> Code
+                  -> [(T.Text, Code)]
+                  -> Code
 compileParameters gen nameTypePairs =
     toIndentedCodes (uncurry gen) nameTypePairs ", "
 
@@ -321,7 +321,7 @@ compileFieldInitializers fields = do
             ListModifier _ -> do
                 let imports = [("nirum.datastructures", ["list_type"])]
                 insertThirdPartyImports imports
-                return [qq|self.$attributeName = List($attributeName)|]
+                return [qq|self.$attributeName = list_type($attributeName)|]
             _ -> return [qq|self.$attributeName = $attributeName|]
       where
         attributeName :: Code

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -302,10 +302,10 @@ toIndentedCodes :: (a -> T.Text) -> [a] -> T.Text -> T.Text
 toIndentedCodes f traversable concatenator =
     T.intercalate concatenator $ map f traversable
 
-toArgumentCode :: (ParameterName -> ParameterType -> Code)
+compileParameters :: (ParameterName -> ParameterType -> Code)
                -> [(T.Text, Code)]
                -> Code
-toArgumentCode gen nameNTypes = toIndentedCodes (uncurry gen) nameNTypes ", "
+compileParameters gen nameNTypes = toIndentedCodes (uncurry gen) nameNTypes ", "
 
 toInitialValueCode :: DS.DeclarationSet Field -> Code
 toInitialValueCode fields =
@@ -458,7 +458,7 @@ class $className($parentClass):
         $nameMaps
     ])
 
-    def __init__(self, {toArgumentCode arg nameNTypes}){ ret "None" }:
+    def __init__(self, {compileParameters arg nameNTypes}){ ret "None" }:
         {toInitialValueCode fields}
         validate_union_type(self)
 
@@ -689,7 +689,7 @@ class $className(object):
         $nameMaps
     ])
 
-    def __init__(self, {toArgumentCode arg nameNTypes}){ret "None"}:
+    def __init__(self, {compileParameters arg nameNTypes}){ret "None"}:
         {toInitialValueCode fields}
         validate_record_type(self)
 

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -319,7 +319,7 @@ compileFieldInitializers fields = do
             SetModifier _ ->
                 return [qq|self.$attributeName = frozenset($attributeName)|]
             ListModifier _ -> do
-                let imports = [("nirum.datastructures", ["List"])]
+                let imports = [("nirum.datastructures", ["list_type"])]
                 insertThirdPartyImports imports
                 return [qq|self.$attributeName = List($attributeName)|]
             _ -> return [qq|self.$attributeName = $attributeName|]

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -311,17 +311,18 @@ compileParameters gen nameTypePairs =
 compileFieldInitializers :: DS.DeclarationSet Field -> CodeGen Code
 compileFieldInitializers fields = do
     initializers <- forM (toList fields) compileFieldInitializer
-    return $ T.intercalate "\n     " initializers
+    return $ T.intercalate "\n        " initializers
   where
     compileFieldInitializer :: Field -> CodeGen Code
     compileFieldInitializer (Field fieldName' fieldType' _) =
         case fieldType' of
-            SetModifier _ -> return [qq|frozenset($attributeName)|]
+            SetModifier _ ->
+                return [qq|self.$attributeName = frozenset($attributeName)|]
             ListModifier _ -> do
                 let imports = [("nirum.datastructures", ["List"])]
                 insertThirdPartyImports imports
-                return [qq|List($attributeName)|]
-            _ -> return attributeName
+                return [qq|self.$attributeName = List($attributeName)|]
+            _ -> return [qq|self.$attributeName = $attributeName|]
       where
         attributeName :: Code
         attributeName = toAttributeName' fieldName'
@@ -686,7 +687,7 @@ class $className(object):
         $nameMaps
     ])
 
-    def __init__(self, {compileParameters arg nameNTypes}){ret "None"}:
+    def __init__(self, {compileParameters arg nameTypePairs}){ret "None"}:
         $initializers
         validate_record_type(self)
 

--- a/test/nirum_fixture/fixture/foo.nrm
+++ b/test/nirum_fixture/fixture/foo.nrm
@@ -67,6 +67,15 @@ union status = run
              | stop
              ;
 
+record song (
+  text name,
+);
+
+record album (
+  text name,
+  [song] tracks,
+);
+
 service null-service ();
 
 service ping-service (
@@ -76,4 +85,13 @@ service ping-service (
         text nonce,
         # Parameter docs.
     ),
+);
+
+record person (
+  irum first-name,
+  irum last-name,
+);
+
+record people (
+  {person} people
 );

--- a/test/nirum_fixture/fixture/foo.nrm
+++ b/test/nirum_fixture/fixture/foo.nrm
@@ -13,7 +13,7 @@ type irum = name;
 enum gender
     # Enum docs.
     = female/yeoseong
-    | male 
+    | male
     ;
 enum eva-char = soryu-asuka-langley
               | ayanami-rei

--- a/test/python/typeconversion_test.py
+++ b/test/python/typeconversion_test.py
@@ -4,7 +4,7 @@ from fixture.foo import Album, Name, People, Person, Song
 
 
 def test_sequence_to_tuple():
-    album = Album(name='25', tracks=[
+    album = Album(name=u'25', tracks=[
         Song(name=u'Hello')
     ])
     assert isinstance(album.tracks, List)

--- a/test/python/typeconversion_test.py
+++ b/test/python/typeconversion_test.py
@@ -1,3 +1,5 @@
+from nirum.datastructures import List
+
 from fixture.foo import Album, Name, People, Person, Song
 
 
@@ -5,7 +7,7 @@ def test_sequence_to_tuple():
     album = Album(name='25', tracks=[
         Song(name='Hello')
     ])
-    assert isinstance(album.tracks, tuple)
+    assert isinstance(album.tracks, List)
     assert hash(album)
 
 

--- a/test/python/typeconversion_test.py
+++ b/test/python/typeconversion_test.py
@@ -5,7 +5,7 @@ from fixture.foo import Album, Name, People, Person, Song
 
 def test_sequence_to_tuple():
     album = Album(name='25', tracks=[
-        Song(name='Hello')
+        Song(name=u'Hello')
     ])
     assert isinstance(album.tracks, List)
     assert hash(album)
@@ -13,8 +13,8 @@ def test_sequence_to_tuple():
 
 def test_set_to_frozenset():
     people = People(people={
-        Person(first_name=Name('hyojun'), last_name=Name('kang')),
-        Person(first_name=Name('minhee'), last_name=Name('hong'))
+        Person(first_name=Name(u'hyojun'), last_name=Name(u'kang')),
+        Person(first_name=Name(u'minhee'), last_name=Name(u'hong'))
     })
     assert isinstance(people.people, frozenset)
     assert hash(people)

--- a/test/python/typeconversion_test.py
+++ b/test/python/typeconversion_test.py
@@ -1,0 +1,18 @@
+from fixture.foo import Album, Name, People, Person, Song
+
+
+def test_sequence_to_tuple():
+    album = Album(name='25', tracks=[
+        Song(name='Hello')
+    ])
+    assert isinstance(album.tracks, tuple)
+    assert hash(album)
+
+
+def test_set_to_frozenset():
+    people = People(people={
+        Person(first_name=Name('hyojun'), last_name=Name('kang')),
+        Person(first_name=Name('minhee'), last_name=Name('hong'))
+    })
+    assert isinstance(people.people, frozenset)
+    assert hash(people)

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist =
 deps =
     six
     flake8
-    nirum>=0.3.7
+    nirum>=0.4.1
     pytest
 commands =
     pip install -e ./nirum_fixture


### PR DESCRIPTION
it fixes spoqa/nirum-python#49. this PR propose convert a type that could be mutable to immutable type always rather than raise error on runtime.