### PR TITLE
Require Python runtime version 0.5.1 or higher

### DIFF
--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -135,7 +135,7 @@ import Nirum.Package.Metadata ( Author (Author, name, email)
 import qualified Nirum.Package.ModuleSet as MS
 
 minimumRuntime :: SV.Version
-minimumRuntime = SV.version 0 4 0 [] []
+minimumRuntime = SV.version 0 5 1 [] []
 
 data Python = Python { packageName :: T.Text
                      , minimumRuntimeVersion :: SV.Version


### PR DESCRIPTION
The previous versions of the Python runtime has several bugs that impact on the use of services.