### PR TITLE
Make generated Python codes refactored for new transport layer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ matrix:
         - python3.6
         - libgmp10
         - upx-ucl
+env:
+# Remove following environment variables after nirum-python 0.6.0 is released.
+- DEVRUNTIME_REPO=dahlia/nirum-python DEVRUNTIME_REF=transport
 cache:
   directories:
   - "$HOME/.stack"

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ on GitHub!
 
 - [nirum-python](https://github.com/spoqa/nirum-python): The official Python
   runtime library for Nirum.
+    - [nirim-python-http](https://github.com/spoqa/nirum-python-http):
+      Nirum HTTP transport for Python.
+    - [nirum-python-wsgi](https://github.com/spoqa/nirum-python-wsgi):
+      Adapt Nirum services to WSGI apps.
 
 [7]: https://github.com/search?q=topic:nirum+fork:false
 [8]: https://github.com/blog/2309-introducing-topics

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,9 @@ platform:
 - x64
 environment:
   STACK_ROOT: C:\sr
+# Remove following environment variables after nirum-python 0.6.0 is released.
+  DEVRUNTIME_REPO: dahlia/nirum-python
+  DEVRUNTIME_REF: transport
 cache:
 - '%STACK_ROOT% -> appveyor.yml'
 - '%LOCALAPPDATA%\Programs\stack -> appveyor.yml'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,7 @@ after_build:
 - ps: ls
 - ps: upx.exe -9 nirum-win-${env:PLATFORM}.exe
 test_script:
-- stack test
+- stack --no-terminal test --jobs 1
 - C:\Python36\Scripts\tox -e devruntime
 - C:\Python36\Scripts\tox
 artifacts:

--- a/src/Nirum/Constructs/Service.hs
+++ b/src/Nirum/Constructs/Service.hs
@@ -1,4 +1,5 @@
 module Nirum.Constructs.Service ( Method ( Method
+                                         , errorType
                                          , methodAnnotations
                                          , methodName
                                          , parameters

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -839,7 +839,7 @@ compileTypeDeclaration
                             ]
     insertThirdPartyImportsA
         [ ("nirum.constructs", [("name_dict_type", "NameDict")])
-        , ("nirum.rpc", [("service_type", "Service")])
+        , ("nirum.service", [("service_type", "Service")])
         , ("nirum.transport", [("transport_type", "Transport")])
         ]
     return [qq|

--- a/test/python/primitive_test.py
+++ b/test/python/primitive_test.py
@@ -3,7 +3,7 @@ import enum
 
 from pytest import raises
 from nirum.rpc import Service
-from six import PY3, text_type
+from six import PY3
 
 from fixture.foo import (CultureAgnosticName, EastAsianName,
                          EvaChar, FloatUnbox, Gender, ImportedTypeUnbox, Irum,
@@ -238,9 +238,11 @@ def test_service():
     assert getattr(PingService, '__nirum_schema_version__') == '0.3.0'
     assert getattr(NullService, '__nirum_schema_version__') == '0.3.0'
     if PY3:
-        assert set(PingService.ping.__annotations__) == {'nonce', 'return'}
-        assert PingService.ping.__annotations__['nonce'] is text_type
-        assert PingService.ping.__annotations__['return'] is bool
+        import typing
+        annots = typing.get_type_hints(PingService.ping)
+        assert set(annots) == {'nonce', 'return'}
+        assert annots['nonce'] is str
+        assert annots['return'] is bool
     with raises(NotImplementedError):
         PingService().ping(u'nonce')
     with raises(NotImplementedError):

--- a/test/python/primitive_test.py
+++ b/test/python/primitive_test.py
@@ -2,7 +2,7 @@
 import enum
 
 from pytest import raises
-from nirum.rpc import Service
+from nirum.service import Service
 from six import PY3
 
 from fixture.foo import (CultureAgnosticName, EastAsianName,

--- a/tox.ini
+++ b/tox.ini
@@ -39,9 +39,9 @@ changedir = {envtmpdir}
 whitelist_externals =
     mkdir
 commands =
-    python -m wget -o master.zip https://github.com/spoqa/nirum-python/archive/master.zip
-    python -m zipfile -e master.zip .
-    python -c 'import glob, os.path; [os.rename(f, os.path.join(".", os.path.basename(f))) for f in glob.glob("nirum-python-master/*")]'
+    python -m wget -o devruntime.zip https://github.com/{env:DEVRUNTIME_REPO:spoqa/nirum-python}/archive/{env:DEVRUNTIME_REF:master}.zip
+    python -m zipfile -e devruntime.zip .
+    python -c 'import glob, os.path; [os.rename(f, os.path.join(".", os.path.basename(f))) for f in glob.glob("nirum-python-*/*")]'
     python setup.py sdist bdist_wheel
     mkdir {distdir}
     python -c 'import glob, os, sys; [os.rename(f, os.path.join(sys.argv[1], os.path.basename(f))) for f in glob.glob("dist/nirum-*")]' {distdir}


### PR DESCRIPTION
This compiler patch is for suggested new transport layer spoqa/nirum-python#79 and related other things.  It also is required by another patch on nirum-python spoqa/nirum-python#92 and need to be merged first.

Key changes:

- Generated constructors of service clients became to take a `nirum.transport.Transport` instance.
- Followed renamed/moved import paths of the runtime classes (e.g. `nirum.rpc.Service` → `nirum.service.Service`).
- The way to avoid name collision between generated types and runtime classes is changed.  The runtime library had provided alternative names like `service_type` for `Service` and generated imports had been like `from nirum.rpc import service_type`, but it's now `from nirum.service import Service as service_type`.

As its build requires transport features made by spoqa/nirum-python#92 (which is not merged yet) and two patches have a circular dependency each other, I temporarily switched the CI scripts to use `DEVRUNTIME_REPO=dahlia/nirum-python DEVRUNTIME_REF=transport`.