### PR TITLE
Remove temporary DEVRUNTIME_* settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,6 @@ matrix:
         - python3.6
         - libgmp10
         - upx-ucl
-env:
-# Remove following environment variables after nirum-python 0.6.0 is released.
-- DEVRUNTIME_REPO=dahlia/nirum-python DEVRUNTIME_REF=transport
 cache:
   directories:
   - "$HOME/.stack"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,6 @@ platform:
 - x64
 environment:
   STACK_ROOT: C:\sr
-# Remove following environment variables after nirum-python 0.6.0 is released.
-  DEVRUNTIME_REPO: dahlia/nirum-python
-  DEVRUNTIME_REF: transport
 cache:
 - '%STACK_ROOT% -> appveyor.yml'
 - '%LOCALAPPDATA%\Programs\stack -> appveyor.yml'


### PR DESCRIPTION
As spoqa/nirum-python#92 was merged, we don't need `DEVRUNTIME_*` settings anymore.