### PR TITLE
Union tag docs now can be in parentheses

### DIFF
--- a/examples/shapes.nrm
+++ b/examples/shapes.nrm
@@ -23,16 +23,20 @@ record point (
     # Record type definition.
 
     offset left/x,
-    # for backward compatibility, you can specify *behind name*.
+    # For backward compatibility, you can specify *behind name*.
 
     offset top,
-    # trailing comma is okay
+    # Trailing comma is okay.
 );
 
 union shape
     # Type constructors in a sum type become translated to subtypes in OO
     # languages, and datatypes in functional languages.
-    = rectangle (point upper-left, point lower-right)
+    = rectangle (
+          # Each tag can have zero or more fields like record types.
+          point upper-left,
+          point lower-right
+      )
     | circle (point origin, offset radius)
     ;
 

--- a/src/Nirum/Parser.hs
+++ b/src/Nirum/Parser.hs
@@ -419,6 +419,11 @@ tag = do
     tagName <- name <?> "union tag name"
     spaces
     paren <- optional $ char '('
+    spaces
+    frontDocs <- optional $ do
+        d <- docs <?> "union tag docs"
+        spaces
+        return d
     fields' <- case paren of
         Just _ -> do
             spaces
@@ -428,10 +433,12 @@ tag = do
             return f
         Nothing -> return empty
     spaces
-    docs' <- optional $ do
-        d <- docs <?> "union tag docs"
-        spaces
-        return d
+    docs' <- case frontDocs of
+        d@(Just _) -> return d
+        Nothing -> optional $ do
+            d <- docs <?> "union tag docs"
+            spaces
+            return d
     annotationSet'' <- annotationsWithDocs annotationSet' docs'
     return $ Tag tagName fields' annotationSet''
 

--- a/test/Nirum/ParserSpec.hs
+++ b/test/Nirum/ParserSpec.hs
@@ -717,14 +717,21 @@ union shape
 union shape
     = circle (point origin, offset radius,)
     # tag docs
-    | rectangle (point upper-left, point lower-right,)
+    | rectangle (
+          # front docs
+          point upper-left, point lower-right,
+      )
     | none
     ;|] `shouldBeRight`
                     a { type' = union'
                             { tags = [ circleTag
                                         { tagAnnotations = singleDocs "tag docs"
                                         }
-                                     , rectTag, noneTag
+                                     , rectTag
+                                        { tagAnnotations =
+                                              singleDocs "front docs"
+                                        }
+                                     , noneTag
                                      ]
                             }
                       }


### PR DESCRIPTION
Fixes #153.

Like record docs, union tag docs also now can be in parentheses e.g.:

```nirum
union U
    = T1 ()
    # Docs after closing parenthesis still work.
    | T2 (
        # Docs after opening parenthesis now becomes supported. 🆕
    )
    ;
```