### PR TITLE
Copy binary to PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY ./stack.yaml /opt/nirum/stack.yaml
 RUN stack build --only-snapshot
 
 COPY . /opt/nirum
-RUN stack build
+RUN stack build --copy-bins
 
 ENV CMD=nirum
 ENTRYPOINT ["./docker-entrypoint.sh"]


### PR DESCRIPTION
`nirum` couldn't be executed because nirum binary didn't be placed on
`PATH`. so i added `--copy-bins` option to copy binary into `PATH`

@dahlia @Kroisse @AiOO @ipdae  help me!