### PR TITLE
Add description field to package metadata

### DIFF
--- a/src/Nirum/Package/Metadata.hs
+++ b/src/Nirum/Package/Metadata.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE GADTs, QuasiQuotes, RankNTypes, ScopedTypeVariables,
              StandaloneDeriving, TypeFamilies #-}
 module Nirum.Package.Metadata ( Author (Author, email, name, uri)
-                              , Metadata (Metadata
+                              , Metadata ( Metadata
                                          , authors
                                          , target
                                          , version

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -117,7 +117,12 @@ import Nirum.Package ( BoundModule
                      , types
                      )
 import Nirum.Package.Metadata ( Author (Author, name, email)
-                              , Metadata (Metadata, authors, target, version)
+                              , Metadata (Metadata
+                                         , authors
+                                         , target
+                                         , version
+                                         , description
+                                         )
                               , MetadataError ( FieldError
                                               , FieldTypeError
                                               , FieldValueError
@@ -1186,6 +1191,7 @@ if sys.version_info < (3, 0):
 setup(
     name='{pName}',
     version='{pVersion}',
+    description=$pDescription,
     author=$author,
     author_email=$authorEmail,
     package_dir=\{'': SOURCE_ROOT},
@@ -1207,6 +1213,10 @@ setup(
     pName = packageName $ target metadata'
     pVersion :: Code
     pVersion = SV.toText $ version metadata'
+    pDescription :: Code
+    pDescription = case description metadata' of
+                     Just value -> T.intercalate "" ["'", value, "'"]
+                     Nothing -> "None"
     strings :: [Code] -> Code
     strings values = T.intercalate ", " $ map stringLiteral (L.sort values)
     author :: Code

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -117,7 +117,7 @@ import Nirum.Package ( BoundModule
                      , types
                      )
 import Nirum.Package.Metadata ( Author (Author, name, email)
-                              , Metadata (Metadata
+                              , Metadata ( Metadata
                                          , authors
                                          , target
                                          , version

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -1215,7 +1215,7 @@ setup(
     pVersion = SV.toText $ version metadata'
     pDescription :: Code
     pDescription = case description metadata' of
-                     Just value -> T.intercalate "" ["'", value, "'"]
+                     Just value -> stringLiteral value
                      Nothing -> "None"
     strings :: [Code] -> Code
     strings values = T.intercalate ", " $ map stringLiteral (L.sort values)

--- a/test/Nirum/CodeBuilderSpec.hs
+++ b/test/Nirum/CodeBuilderSpec.hs
@@ -38,6 +38,7 @@ modules' = case m of
 package :: Package DummyTarget
 package = Package { metadata = Metadata { version = SV.version 0 0 1 [] []
                                         , authors = []
+                                        , description = Nothing
                                         , target = DummyTarget
                                         }
                   , modules = modules'

--- a/test/Nirum/Package/MetadataSpec.hs
+++ b/test/Nirum/Package/MetadataSpec.hs
@@ -121,6 +121,13 @@ spec =
                         , "string"
                         , "array of 0 values"
                         )
+                      , ( [q|version = "1.2.3"
+                             description = 123
+                          |]
+                        , "description"
+                        , "string"
+                        , "integer (123)"
+                        )
                       ] $ \ (toml, field, expected, actual) -> do
                         let Left e = parse toml
                             FieldTypeError field' expected' actual' = e

--- a/test/Nirum/PackageSpec.hs
+++ b/test/Nirum/PackageSpec.hs
@@ -35,7 +35,12 @@ import Nirum.Package ( BoundModule (boundPackage, modulePath)
                      , scanPackage
                      , types
                      )
-import Nirum.Package.Metadata ( Metadata (Metadata, authors, target, version)
+import Nirum.Package.Metadata ( Metadata (Metadata
+                                         , authors
+                                         , target
+                                         , version
+                                         , description
+                                         )
                               , MetadataError (FormatError)
                               , Target (targetName)
                               )
@@ -56,6 +61,7 @@ createPackage metadata' modules' =
 createValidPackage :: t -> Package t
 createValidPackage t = createPackage Metadata { version = SV.initial
                                               , authors = []
+                                              , description = Nothing
                                               , target = t
                                               } validModules
 
@@ -103,6 +109,7 @@ testPackage target' = do
                               ] :: [(ModulePath, Module)]
                     metadata' = Metadata { version = SV.version 0 3 0 [] []
                                          , authors = []
+                                         , description = Nothing
                                          , target = target'
                                          }
                 metadata package `shouldBe` metadata'

--- a/test/Nirum/PackageSpec.hs
+++ b/test/Nirum/PackageSpec.hs
@@ -35,7 +35,7 @@ import Nirum.Package ( BoundModule (boundPackage, modulePath)
                      , scanPackage
                      , types
                      )
-import Nirum.Package.Metadata ( Metadata (Metadata
+import Nirum.Package.Metadata ( Metadata ( Metadata
                                          , authors
                                          , target
                                          , version

--- a/test/Nirum/Targets/PythonSpec.hs
+++ b/test/Nirum/Targets/PythonSpec.hs
@@ -37,7 +37,11 @@ import Nirum.Constructs.TypeExpression ( TypeExpression ( ListModifier
                                        )
 import Nirum.Package (Package (metadata, modules), resolveBoundModule)
 import Nirum.Package.Metadata ( Author (Author, email, name, uri)
-                              , Metadata (Metadata, authors, target, version)
+                              , Metadata (Metadata
+                                         , authors
+                                         , target
+                                         , version
+                                         , description)
                               , Target (compilePackage)
                               )
 import qualified Nirum.Package.ModuleSet as MS
@@ -95,6 +99,7 @@ makeDummySource' pathPrefix m renames =
                     , uri = Nothing
                     }
               ]
+        , description = Just "Package description"
         , target = Python "sample-package" minimumRuntime renames
         }
     pkg :: Package Python

--- a/test/Nirum/Targets/PythonSpec.hs
+++ b/test/Nirum/Targets/PythonSpec.hs
@@ -37,7 +37,7 @@ import Nirum.Constructs.TypeExpression ( TypeExpression ( ListModifier
                                        )
 import Nirum.Package (Package (metadata, modules), resolveBoundModule)
 import Nirum.Package.Metadata ( Author (Author, email, name, uri)
-                              , Metadata (Metadata
+                              , Metadata ( Metadata
                                          , authors
                                          , target
                                          , version

--- a/test/nirum_fixture/package.toml
+++ b/test/nirum_fixture/package.toml
@@ -1,4 +1,5 @@
 version = "0.3.0"
+description = "Package description"
 
 [[authors]]
 name = "nirum"

--- a/test/python/setup_test.py
+++ b/test/python/setup_test.py
@@ -21,3 +21,4 @@ def test_setup_metadata():
         'renamed', 'renamed.foo', 'renamed.foo.bar',
     }
     assert ['0.3.0'] == pkg['Version']
+    assert ['Package description'] == pkg['Summary']


### PR DESCRIPTION
This patch adds the description field to package metadata. (#100)