### PR TITLE
Add license field to package metadata

### DIFF
--- a/docs/package.md
+++ b/docs/package.md
@@ -43,6 +43,7 @@ is an example:
 
     version = "1.0.0"  # (required)
     description = "Short description on the package"
+    license = "MIT"
 
     [[authors]]
     name = "John Doe"  # (required)
@@ -56,6 +57,9 @@ It consists of the following fields (*emphasized fields* are required):
 
 `description` (string)
 :   An optional short description of the package.
+
+`license` (string)
+:   An optional license of the package.
 
 `authors` (array of tables)
 :   The list of authors.  Note that it can be empty, but `name` field is

--- a/src/Nirum/Package/Metadata.hs
+++ b/src/Nirum/Package/Metadata.hs
@@ -6,6 +6,7 @@ module Nirum.Package.Metadata ( Author (Author, email, name, uri)
                                          , target
                                          , version
                                          , description
+                                         , license
                                          )
                               , MetadataError ( FieldError
                                               , FieldTypeError
@@ -96,11 +97,12 @@ deriving instance (Ord t, Target t) => Ord (Package t)
 deriving instance (Show t, Target t) => Show (Package t)
 
 packageTarget :: Target t => Package t -> t
-packageTarget Package { metadata = Metadata _ _ _ t } = t
+packageTarget Package { metadata = Metadata _ _ _ _ t } = t
 
 data Metadata t =
     Metadata { version :: SV.Version
              , description :: Maybe Text
+             , license :: Maybe Text
              , authors :: [Author]
              , target :: (Eq t, Ord t, Show t, Target t) => t
              }
@@ -181,6 +183,7 @@ parseMetadata metadataPath' tomlText = do
     version' <- versionField "version" table
     authors' <- authorsField "authors" table
     description' <- optional $ stringField "description" table
+    license' <- optional $ stringField "license" table
     targets <- case tableField "targets" table of
         Left (FieldError _) -> Right HM.empty
         otherwise' -> otherwise'
@@ -194,6 +197,7 @@ parseMetadata metadataPath' tomlText = do
         otherwise' -> otherwise'
     return Metadata { version = version'
                     , description = description'
+                    , license = license'
                     , authors = authors'
                     , target = target'
                     }

--- a/src/Nirum/Package/Metadata.hs
+++ b/src/Nirum/Package/Metadata.hs
@@ -97,7 +97,7 @@ deriving instance (Ord t, Target t) => Ord (Package t)
 deriving instance (Show t, Target t) => Show (Package t)
 
 packageTarget :: Target t => Package t -> t
-packageTarget Package { metadata = Metadata _ _ _ _ t } = t
+packageTarget Package { metadata = Metadata { target = t } } = t
 
 data Metadata t =
     Metadata { version :: SV.Version

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -1187,8 +1187,7 @@ SOURCE_ROOT = '{sourceDirectory Python3}'
 if sys.version_info < (3, 0):
     SOURCE_ROOT = '{sourceDirectory Python2}'
 
-# TODO: description, long_description, url, license,
-#       keywords, classifiers
+# TODO: long_description, url, keywords, classifiers
 setup(
     name='{pName}',
     version='{pVersion}',

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -122,6 +122,7 @@ import Nirum.Package.Metadata ( Author (Author, name, email)
                                          , target
                                          , version
                                          , description
+                                         , license
                                          )
                               , MetadataError ( FieldError
                                               , FieldTypeError
@@ -1192,6 +1193,7 @@ setup(
     name='{pName}',
     version='{pVersion}',
     description=$pDescription,
+    license=$pLicense,
     author=$author,
     author_email=$authorEmail,
     package_dir=\{'': SOURCE_ROOT},
@@ -1215,6 +1217,10 @@ setup(
     pVersion = SV.toText $ version metadata'
     pDescription :: Code
     pDescription = case description metadata' of
+                     Just value -> stringLiteral value
+                     Nothing -> "None"
+    pLicense :: Code
+    pLicense = case license metadata' of
                      Just value -> stringLiteral value
                      Nothing -> "None"
     strings :: [Code] -> Code

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -1215,14 +1215,14 @@ setup(
     pName = packageName $ target metadata'
     pVersion :: Code
     pVersion = SV.toText $ version metadata'
+    fromMaybeToMeta :: Maybe T.Text -> T.Text
+    fromMaybeToMeta s = case s of
+                          Just value -> stringLiteral value
+                          Nothing -> "None"
     pDescription :: Code
-    pDescription = case description metadata' of
-                     Just value -> stringLiteral value
-                     Nothing -> "None"
+    pDescription = fromMaybeToMeta $ description metadata'
     pLicense :: Code
-    pLicense = case license metadata' of
-                     Just value -> stringLiteral value
-                     Nothing -> "None"
+    pLicense = fromMaybeToMeta $ license metadata'
     strings :: [Code] -> Code
     strings values = T.intercalate ", " $ map stringLiteral (L.sort values)
     author :: Code

--- a/test/Nirum/CodeBuilderSpec.hs
+++ b/test/Nirum/CodeBuilderSpec.hs
@@ -39,6 +39,7 @@ package :: Package DummyTarget
 package = Package { metadata = Metadata { version = SV.version 0 0 1 [] []
                                         , authors = []
                                         , description = Nothing
+                                        , license = Nothing
                                         , target = DummyTarget
                                         }
                   , modules = modules'

--- a/test/Nirum/Package/MetadataSpec.hs
+++ b/test/Nirum/Package/MetadataSpec.hs
@@ -128,6 +128,13 @@ spec =
                         , "string"
                         , "integer (123)"
                         )
+                      , ( [q|version = "1.2.3"
+                             license = 123
+                          |]
+                        , "license"
+                        , "string"
+                        , "integer (123)"
+                        )
                       ] $ \ (toml, field, expected, actual) -> do
                         let Left e = parse toml
                             FieldTypeError field' expected' actual' = e

--- a/test/Nirum/PackageSpec.hs
+++ b/test/Nirum/PackageSpec.hs
@@ -40,6 +40,7 @@ import Nirum.Package.Metadata ( Metadata ( Metadata
                                          , target
                                          , version
                                          , description
+                                         , license
                                          )
                               , MetadataError (FormatError)
                               , Target (targetName)
@@ -62,6 +63,7 @@ createValidPackage :: t -> Package t
 createValidPackage t = createPackage Metadata { version = SV.initial
                                               , authors = []
                                               , description = Nothing
+                                              , license = Nothing
                                               , target = t
                                               } validModules
 
@@ -110,6 +112,7 @@ testPackage target' = do
                     metadata' = Metadata { version = SV.version 0 3 0 [] []
                                          , authors = []
                                          , description = Nothing
+                                         , license = Nothing
                                          , target = target'
                                          }
                 metadata package `shouldBe` metadata'

--- a/test/Nirum/Targets/PythonSpec.hs
+++ b/test/Nirum/Targets/PythonSpec.hs
@@ -41,7 +41,8 @@ import Nirum.Package.Metadata ( Author (Author, email, name, uri)
                                          , authors
                                          , target
                                          , version
-                                         , description)
+                                         , description
+                                         , license)
                               , Target (compilePackage)
                               )
 import qualified Nirum.Package.ModuleSet as MS
@@ -100,6 +101,7 @@ makeDummySource' pathPrefix m renames =
                     }
               ]
         , description = Just "Package description"
+        , license = Just "MIT"
         , target = Python "sample-package" minimumRuntime renames
         }
     pkg :: Package Python

--- a/test/nirum_fixture/package.toml
+++ b/test/nirum_fixture/package.toml
@@ -1,5 +1,6 @@
 version = "0.3.0"
 description = "Package description"
+license = "MIT"
 
 [[authors]]
 name = "nirum"

--- a/test/python/setup_test.py
+++ b/test/python/setup_test.py
@@ -22,3 +22,4 @@ def test_setup_metadata():
     }
     assert ['0.3.0'] == pkg['Version']
     assert ['Package description'] == pkg['Summary']
+    assert ['MIT'] == pkg['License']


### PR DESCRIPTION
This patch adds the license field to package metadata. (#100)