### PR TITLE
Add keywords field to package metadata

### DIFF
--- a/docs/package.md
+++ b/docs/package.md
@@ -44,6 +44,7 @@ is an example:
     version = "1.0.0"  # (required)
     description = "Short description on the package"
     license = "MIT"
+    keywords = "sample example nirum"
 
     [[authors]]
     name = "John Doe"  # (required)
@@ -60,6 +61,9 @@ It consists of the following fields (*emphasized fields* are required):
 
 `license` (string)
 :   An optional license of the package.
+
+`keywords` (string)
+:   An optional keywords of the package.
 
 `authors` (array of tables)
 :   The list of authors.  Note that it can be empty, but `name` field is

--- a/src/Nirum/Package/Metadata.hs
+++ b/src/Nirum/Package/Metadata.hs
@@ -7,7 +7,7 @@ module Nirum.Package.Metadata ( Author (Author, email, name, uri)
                                          , version
                                          , description
                                          , license
-                                         , packageKeywords
+                                         , keywords
                                          )
                               , MetadataError ( FieldError
                                               , FieldTypeError
@@ -104,7 +104,7 @@ data Metadata t =
     Metadata { version :: SV.Version
              , description :: Maybe Text
              , license :: Maybe Text
-             , packageKeywords :: Maybe Text
+             , keywords :: Maybe Text
              , authors :: [Author]
              , target :: (Eq t, Ord t, Show t, Target t) => t
              }
@@ -201,7 +201,7 @@ parseMetadata metadataPath' tomlText = do
     return Metadata { version = version'
                     , description = description'
                     , license = license'
-                    , packageKeywords = keywords'
+                    , keywords = keywords'
                     , authors = authors'
                     , target = target'
                     }

--- a/src/Nirum/Package/Metadata.hs
+++ b/src/Nirum/Package/Metadata.hs
@@ -7,6 +7,7 @@ module Nirum.Package.Metadata ( Author (Author, email, name, uri)
                                          , version
                                          , description
                                          , license
+                                         , packageKeywords
                                          )
                               , MetadataError ( FieldError
                                               , FieldTypeError
@@ -103,6 +104,7 @@ data Metadata t =
     Metadata { version :: SV.Version
              , description :: Maybe Text
              , license :: Maybe Text
+             , packageKeywords :: Maybe Text
              , authors :: [Author]
              , target :: (Eq t, Ord t, Show t, Target t) => t
              }
@@ -184,6 +186,7 @@ parseMetadata metadataPath' tomlText = do
     authors' <- authorsField "authors" table
     description' <- optional $ stringField "description" table
     license' <- optional $ stringField "license" table
+    keywords' <- optional $ stringField "keywords" table
     targets <- case tableField "targets" table of
         Left (FieldError _) -> Right HM.empty
         otherwise' -> otherwise'
@@ -198,6 +201,7 @@ parseMetadata metadataPath' tomlText = do
     return Metadata { version = version'
                     , description = description'
                     , license = license'
+                    , packageKeywords = keywords'
                     , authors = authors'
                     , target = target'
                     }

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -1209,9 +1209,9 @@ setup(
   where
     target' :: Python
     target' = target metadata'
-    csStrings :: [T.Text] -> T.Text
-    csStrings [] = "None"
-    csStrings s = stringLiteral $ T.intercalate ", " s
+    csStrings :: T.Text -> [T.Text] -> T.Text
+    csStrings _ [] = "None"
+    csStrings d s = stringLiteral $ T.intercalate d s
     pName :: Code
     pName = packageName $ target metadata'
     pVersion :: Code
@@ -1225,13 +1225,15 @@ setup(
     pLicense :: Code
     pLicense = fromMaybeToMeta $ license metadata'
     pKeywords :: Code
-    pKeywords = fromMaybeToMeta $ MD.keywords metadata'
+    pKeywords = csStrings " " $ MD.keywords metadata'
     strings :: [Code] -> Code
     strings values = T.intercalate ", " $ map stringLiteral (L.sort values)
     author :: Code
-    author = csStrings [aName | Author { name = aName } <- authors metadata']
+    author = csStrings ", " [aName
+                            | Author { name = aName } <- authors metadata'
+                            ]
     authorEmail :: Code
-    authorEmail = csStrings [ decodeUtf8 (E.toByteString e)
+    authorEmail = csStrings ", " [ decodeUtf8 (E.toByteString e)
                             | Author { email = Just e } <- authors metadata'
                             ]
     pPackages :: Code

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -123,7 +123,6 @@ import Nirum.Package.Metadata ( Author (Author, name, email)
                                          , version
                                          , description
                                          , license
-                                         , packageKeywords
                                          )
                               , MetadataError ( FieldError
                                               , FieldTypeError
@@ -144,6 +143,7 @@ import Nirum.Package.Metadata ( Author (Author, name, email)
                               , versionField
                               )
 import qualified Nirum.Package.ModuleSet as MS
+import qualified Nirum.Package.Metadata as MD
 
 minimumRuntime :: SV.Version
 minimumRuntime = SV.version 0 6 0 [] []
@@ -1225,7 +1225,7 @@ setup(
     pLicense :: Code
     pLicense = fromMaybeToMeta $ license metadata'
     pKeywords :: Code
-    pKeywords = fromMaybeToMeta $ packageKeywords metadata'
+    pKeywords = fromMaybeToMeta $ MD.keywords metadata'
     strings :: [Code] -> Code
     strings values = T.intercalate ", " $ map stringLiteral (L.sort values)
     author :: Code

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -123,6 +123,7 @@ import Nirum.Package.Metadata ( Author (Author, name, email)
                                          , version
                                          , description
                                          , license
+                                         , packageKeywords
                                          )
                               , MetadataError ( FieldError
                                               , FieldTypeError
@@ -1187,12 +1188,13 @@ SOURCE_ROOT = '{sourceDirectory Python3}'
 if sys.version_info < (3, 0):
     SOURCE_ROOT = '{sourceDirectory Python2}'
 
-# TODO: long_description, url, keywords, classifiers
+# TODO: long_description, url, classifiers
 setup(
     name='{pName}',
     version='{pVersion}',
     description=$pDescription,
     license=$pLicense,
+    keywords=$pKeywords,
     author=$author,
     author_email=$authorEmail,
     package_dir=\{'': SOURCE_ROOT},
@@ -1222,6 +1224,8 @@ setup(
     pDescription = fromMaybeToMeta $ description metadata'
     pLicense :: Code
     pLicense = fromMaybeToMeta $ license metadata'
+    pKeywords :: Code
+    pKeywords = fromMaybeToMeta $ packageKeywords metadata'
     strings :: [Code] -> Code
     strings values = T.intercalate ", " $ map stringLiteral (L.sort values)
     author :: Code

--- a/test/Nirum/CodeBuilderSpec.hs
+++ b/test/Nirum/CodeBuilderSpec.hs
@@ -40,7 +40,7 @@ package = Package { metadata = Metadata { version = SV.version 0 0 1 [] []
                                         , authors = []
                                         , description = Nothing
                                         , license = Nothing
-                                        , keywords = Nothing
+                                        , keywords = []
                                         , target = DummyTarget
                                         }
                   , modules = modules'

--- a/test/Nirum/CodeBuilderSpec.hs
+++ b/test/Nirum/CodeBuilderSpec.hs
@@ -40,7 +40,7 @@ package = Package { metadata = Metadata { version = SV.version 0 0 1 [] []
                                         , authors = []
                                         , description = Nothing
                                         , license = Nothing
-                                        , packageKeywords = Nothing
+                                        , keywords = Nothing
                                         , target = DummyTarget
                                         }
                   , modules = modules'

--- a/test/Nirum/CodeBuilderSpec.hs
+++ b/test/Nirum/CodeBuilderSpec.hs
@@ -40,6 +40,7 @@ package = Package { metadata = Metadata { version = SV.version 0 0 1 [] []
                                         , authors = []
                                         , description = Nothing
                                         , license = Nothing
+                                        , packageKeywords = Nothing
                                         , target = DummyTarget
                                         }
                   , modules = modules'

--- a/test/Nirum/Package/MetadataSpec.hs
+++ b/test/Nirum/Package/MetadataSpec.hs
@@ -135,6 +135,13 @@ spec =
                         , "string"
                         , "integer (123)"
                         )
+                      , ( [q|version = "1.2.3"
+                             keywords = 789
+                          |]
+                        , "keywords"
+                        , "string"
+                        , "integer (789)"
+                        )
                       ] $ \ (toml, field, expected, actual) -> do
                         let Left e = parse toml
                             FieldTypeError field' expected' actual' = e

--- a/test/Nirum/Package/MetadataSpec.hs
+++ b/test/Nirum/Package/MetadataSpec.hs
@@ -136,11 +136,11 @@ spec =
                         , "integer (123)"
                         )
                       , ( [q|version = "1.2.3"
-                             keywords = 789
+                             keywords = "sample example nirum"
                           |]
                         , "keywords"
-                        , "string"
-                        , "integer (789)"
+                        , "array"
+                        , "string (sample example nirum)"
                         )
                       ] $ \ (toml, field, expected, actual) -> do
                         let Left e = parse toml

--- a/test/Nirum/PackageSpec.hs
+++ b/test/Nirum/PackageSpec.hs
@@ -41,6 +41,7 @@ import Nirum.Package.Metadata ( Metadata ( Metadata
                                          , version
                                          , description
                                          , license
+                                         , packageKeywords
                                          )
                               , MetadataError (FormatError)
                               , Target (targetName)
@@ -64,6 +65,7 @@ createValidPackage t = createPackage Metadata { version = SV.initial
                                               , authors = []
                                               , description = Nothing
                                               , license = Nothing
+                                              , packageKeywords = Nothing
                                               , target = t
                                               } validModules
 
@@ -113,6 +115,7 @@ testPackage target' = do
                                          , authors = []
                                          , description = Nothing
                                          , license = Nothing
+                                         , packageKeywords = Nothing
                                          , target = target'
                                          }
                 metadata package `shouldBe` metadata'

--- a/test/Nirum/PackageSpec.hs
+++ b/test/Nirum/PackageSpec.hs
@@ -65,7 +65,7 @@ createValidPackage t = createPackage Metadata { version = SV.initial
                                               , authors = []
                                               , description = Nothing
                                               , license = Nothing
-                                              , keywords = Nothing
+                                              , keywords = []
                                               , target = t
                                               } validModules
 
@@ -115,7 +115,7 @@ testPackage target' = do
                                          , authors = []
                                          , description = Nothing
                                          , license = Nothing
-                                         , keywords = Nothing
+                                         , keywords = []
                                          , target = target'
                                          }
                 metadata package `shouldBe` metadata'

--- a/test/Nirum/PackageSpec.hs
+++ b/test/Nirum/PackageSpec.hs
@@ -41,7 +41,7 @@ import Nirum.Package.Metadata ( Metadata ( Metadata
                                          , version
                                          , description
                                          , license
-                                         , packageKeywords
+                                         , keywords
                                          )
                               , MetadataError (FormatError)
                               , Target (targetName)
@@ -65,7 +65,7 @@ createValidPackage t = createPackage Metadata { version = SV.initial
                                               , authors = []
                                               , description = Nothing
                                               , license = Nothing
-                                              , packageKeywords = Nothing
+                                              , keywords = Nothing
                                               , target = t
                                               } validModules
 
@@ -115,7 +115,7 @@ testPackage target' = do
                                          , authors = []
                                          , description = Nothing
                                          , license = Nothing
-                                         , packageKeywords = Nothing
+                                         , keywords = Nothing
                                          , target = target'
                                          }
                 metadata package `shouldBe` metadata'

--- a/test/Nirum/Targets/PythonSpec.hs
+++ b/test/Nirum/Targets/PythonSpec.hs
@@ -42,7 +42,9 @@ import Nirum.Package.Metadata ( Author (Author, email, name, uri)
                                          , target
                                          , version
                                          , description
-                                         , license)
+                                         , license
+                                         , packageKeywords
+                                         )
                               , Target (compilePackage)
                               )
 import qualified Nirum.Package.ModuleSet as MS
@@ -102,6 +104,7 @@ makeDummySource' pathPrefix m renames =
               ]
         , description = Just "Package description"
         , license = Just "MIT"
+        , packageKeywords = Just "test example examples"
         , target = Python "sample-package" minimumRuntime renames
         }
     pkg :: Package Python

--- a/test/Nirum/Targets/PythonSpec.hs
+++ b/test/Nirum/Targets/PythonSpec.hs
@@ -43,7 +43,7 @@ import Nirum.Package.Metadata ( Author (Author, email, name, uri)
                                          , version
                                          , description
                                          , license
-                                         , packageKeywords
+                                         , keywords
                                          )
                               , Target (compilePackage)
                               )
@@ -104,7 +104,7 @@ makeDummySource' pathPrefix m renames =
               ]
         , description = Just "Package description"
         , license = Just "MIT"
-        , packageKeywords = Just "test example examples"
+        , keywords = Just "test example examples"
         , target = Python "sample-package" minimumRuntime renames
         }
     pkg :: Package Python

--- a/test/Nirum/Targets/PythonSpec.hs
+++ b/test/Nirum/Targets/PythonSpec.hs
@@ -104,7 +104,7 @@ makeDummySource' pathPrefix m renames =
               ]
         , description = Just "Package description"
         , license = Just "MIT"
-        , keywords = Just "test example examples"
+        , keywords = ["sample", "example", "nirum"]
         , target = Python "sample-package" minimumRuntime renames
         }
     pkg :: Package Python

--- a/test/nirum_fixture/package.toml
+++ b/test/nirum_fixture/package.toml
@@ -1,7 +1,7 @@
 version = "0.3.0"
 description = "Package description"
 license = "MIT"
-keywords = "test example examples"
+keywords = ["sample", "example", "nirum"]
 
 [[authors]]
 name = "nirum"

--- a/test/nirum_fixture/package.toml
+++ b/test/nirum_fixture/package.toml
@@ -1,6 +1,7 @@
 version = "0.3.0"
 description = "Package description"
 license = "MIT"
+keywords = "test example examples"
 
 [[authors]]
 name = "nirum"


### PR DESCRIPTION
This patch adds the keywords field to package metadata. (#100)

I named keywords metadata to `packageKeywords` because of a conflict with Python keywords in `Nirum/Targets/Python.hs`.