### PR TITLE
Rename mro not to overlap with Python keyword

### DIFF
--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -674,7 +674,7 @@ compileTypeDeclaration _ d@TypeDeclaration { typename = typename'
             "\n"
             [ T.concat [ compileDocsComment "    " m
                        , "\n    "
-                       , toAttributeName' memberName
+                       , toEnumMemberName memberName
                        , " = '"
                        , I.toSnakeCaseText bn
                        , "'"
@@ -700,6 +700,16 @@ $memberNames
     ){ ret className }:
         return cls(value.replace('-', '_'))  # FIXME: validate input
 |]
+  where
+    memberKeywords :: [T.Text]
+    memberKeywords = ["mro"]
+    toEnumMemberName :: Name -> T.Text
+    toEnumMemberName name' = if attributeName `elem` memberKeywords
+                            then T.snoc attributeName '_'
+                            else attributeName
+      where
+        attributeName :: T.Text
+        attributeName = toAttributeName' name'
 compileTypeDeclaration src d@TypeDeclaration { typename = typename'
                                              , type' = RecordType fields
                                              } = do

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -705,8 +705,8 @@ $memberNames
     memberKeywords = ["mro"]
     toEnumMemberName :: Name -> T.Text
     toEnumMemberName name' = if attributeName `elem` memberKeywords
-                            then T.snoc attributeName '_'
-                            else attributeName
+                             then attributeName `T.snoc` '_'
+                             else attributeName
       where
         attributeName :: T.Text
         attributeName = toAttributeName' name'

--- a/test/nirum_fixture/fixture/foo.nrm
+++ b/test/nirum_fixture/fixture/foo.nrm
@@ -21,6 +21,9 @@ enum eva-char = soryu-asuka-langley
               | katsuragi-misato
               | nagisa-kaworu
               ;
+enum duplicate-keyword = mro
+                       | no-mro
+                       ;
 
 record point1 (
     # Record docs.

--- a/test/python/primitive_test.py
+++ b/test/python/primitive_test.py
@@ -5,8 +5,9 @@ from pytest import raises
 from nirum.service import Service
 from six import PY3
 
-from fixture.foo import (CultureAgnosticName, Dog, EastAsianName,
-                         EvaChar, FloatUnbox, Gender, ImportedTypeUnbox, Irum,
+from fixture.foo import (CultureAgnosticName, Dog, DuplicateKeyword,
+                         EastAsianName, EvaChar,
+                         FloatUnbox, Gender, ImportedTypeUnbox, Irum,
                          Line, MixedName, NullService,
                          Point1, Point2, Point3d, Pop, PingService, Product,
                          Rnb, Run, Stop, Way, WesternName)
@@ -265,3 +266,14 @@ def test_service():
         PingService().ping(nonce=u'nonce')
     with raises(TypeError):
         PingService().ping(wrongkwd=u'a')
+
+
+def test_enum_duplicate_member_name():
+    assert hasattr(DuplicateKeyword, 'mro_')
+    assert hasattr(DuplicateKeyword, 'no_mro')
+    assert (DuplicateKeyword.__nirum_deserialize__(u'mro') ==
+            DuplicateKeyword.mro_)
+    assert (DuplicateKeyword.__nirum_deserialize__(u'no-mro') ==
+            DuplicateKeyword.no_mro)
+    assert DuplicateKeyword.mro_.__nirum_serialize__() == 'mro'
+    assert DuplicateKeyword.no_mro.__nirum_serialize__() == 'no_mro'


### PR DESCRIPTION
Fix https://github.com/spoqa/nirum/issues/185.

Add `_` at the end of member name when it is duplicated with Python keyword (eg. `mro`).