### PR TITLE
Named and multiple arguments for annotations

### DIFF
--- a/docs/annotation.md
+++ b/docs/annotation.md
@@ -1,0 +1,131 @@
+Annotations
+===========
+
+Annotations can be attached to any declarations, and purpose to be used
+as directive or metadata by target compiler or runtime library.
+
+Each annotation starts with an `@` character, and its name follows,
+e.g., `@foo`.  Annotation names have the same rule to other Nirum identifiers,
+but there's no separation of facial and behind names.
+
+There are annotations defined and used by a target compiler, or more than one
+targets.  If an annotation that no target defined is used, they are merely no-op
+(i.e., ignored and even not errored).
+
+Nirum annotations are similar to Java's one or C#'s attributes.
+
+
+Declarations
+------------
+
+All declarations in Nirum can attach annotations.  Declarations in Nirum mean
+things that have their own name, e.g., imports, records, fields, union tags,
+service methods, method parameters.  In other words, any things that can have
+docs comments also can have annotations.
+
+Each declaration is allowed to have multiple annotations, but their name cannot
+be duplicated.
+
+For example, the following code is allowed:
+
+~~~~~~~~ nirum
+@foo
+@bar(baz = "qux")
+boxed filename (text);
+~~~~~~~~
+
+Whereas the following code is disallowed:
+
+~~~~~~~~ nirum
+@foo
+@foo(baz = "qux")  // `foo` is duplicated
+boxed filename (text);
+~~~~~~~~
+
+
+Arguments
+---------
+
+Annotations have zero or more arguments.  Every parameter is named, and names
+cannot be duplicated in an annotation.  Annotation arguments follow
+an annotation name and are wrapped by parentheses.  An `=` operator is placed
+between each parameter name and its argument value.  Arguments are separated
+by a comma, and an optional trailing comma is also allowed.  E.g.:
+
+~~~~~~~~ nirum
+@foo()
+@bar(baz = "qux")
+@quux(corge = "grault", garply = "waldo", fred = "plugh",)
+boxed filename (text);
+~~~~~~~~
+
+Currently, argument values are only allowed to be a text (which is wrapped by
+double quotes), but they could be extended to other types (e.g., integer).
+Note that C-style escape sequences work between double quotes, e.g.:
+
+~~~~~~~~ nirum
+@foo(bar = "Escape double quotes (\") with backslashes (\\).")
+boxed filename (text);
+~~~~~~~~
+
+
+Common annotations
+------------------
+
+The following annotations are common among more than one target languages.
+For target-specific annotations, read each target's docs.
+
+
+### `@docs` (`docs`)
+
+`@docs` annotations represent docs comments (`# ...`).  The following two
+examples are equivalent, and the former is internally transformed to the latter:
+
+~~~~~~~~ nirum
+# Docs comments are transformed to `@docs` annotations.
+boxed filename (text);
+~~~~~~~~
+
+~~~~~~~~ nirum
+@docs(docs = "Docs comments are transformed to `@docs` annotations.\n")
+boxed filename (text);
+~~~~~~~~
+
+It is primarily for simplifying internal syntax tree, but can be used at runtime
+for other purposes.
+
+Since all docs comments become transformed to `@docs` annotations,
+a declaration cannot have both a docs comment and a `@docs` annotation at
+a time.
+
+`docs`
+:   A docs text.
+
+
+### `@error`
+
+Many object-oriented languages (e.g., Java, Python) require exception classes
+to inherit a specific base class (e.g., `Exception`) to be thrown.
+`@error` annotation is a hint for such languages to make a record or a union to
+inherit that.
+
+For example, the following first Nirum code is compiled to the second Python
+code:
+
+~~~~~~~~ nirum
+@error
+union file-error = file-not-found
+                 | file-not-readable
+                 ;
+~~~~~~~~
+
+~~~~~~~~ python
+class FileError(Exception):
+    ...
+
+class FileNotFound(FileError):
+    ...
+
+class FileNotReadable(FileError):
+    ...
+~~~~~~~~

--- a/lint.sh
+++ b/lint.sh
@@ -28,7 +28,8 @@ scan=(stack exec scan --)
 scanout="$(mktemp)"
 find src test -name '*.hs' -and -not -exec grep -q TemplateHaskell {} \; \
     -print0 | \
-        xargs -0 "${scan[@]}" -t -j false -c false > "$scanout"
+        xargs -0 "${scan[@]}" -t -j false -c false | \
+        grep -v 'back slash at line end .may disturb cpp.' || true > "$scanout"
 cat "$scanout"
 if [[ "$(cat "$scanout")" != "" ]]; then
   exit 1

--- a/src/Nirum/Constructs/Annotation/Internal.hs
+++ b/src/Nirum/Constructs/Annotation/Internal.hs
@@ -1,55 +1,59 @@
 {-# LANGUAGE QuasiQuotes #-}
-module Nirum.Constructs.Annotation.Internal ( Annotation ( Annotation
-                                                         , metadata
-                                                         , name
-                                                         )
-                                            , AnnotationSet ( AnnotationSet
-                                                            , annotations
-                                                            )
-                                            , Metadata
-                                            , fromTuple
-                                            ) where
+module Nirum.Constructs.Annotation.Internal
+    ( Annotation ( Annotation
+                 , arguments
+                 , name
+                 )
+    , AnnotationArgumentSet
+    , AnnotationSet ( AnnotationSet
+                    , annotations
+                    )
+    ) where
 
 import qualified Data.Char as C
+
 import qualified Data.Map.Strict as M
 import qualified Data.Text as T
 import Text.InterpolatedString.Perl6 (qq)
 
 import Nirum.Constructs (Construct (toCode))
-import Nirum.Constructs.Docs (annotationDocsName)
+import Nirum.Constructs.Docs
 import Nirum.Constructs.Identifier (Identifier)
 
-
-type Metadata = T.Text
+type AnnotationArgumentSet = M.Map Identifier T.Text
 
 -- | Annotation for 'Declaration'.
 data Annotation = Annotation { name :: Identifier
-                             , metadata :: Maybe Metadata
+                             , arguments :: AnnotationArgumentSet
                              } deriving (Eq, Ord, Show)
 
 instance Construct Annotation where
-    toCode Annotation {name = n, metadata = Just m} =
-        [qq|@{toCode n}("$m'")|]
+    toCode Annotation { name = n, arguments = args }
+      | M.null args = '@' `T.cons` toCode n
+      | otherwise = [qq|@{toCode n}({showArgs $ M.toList args})|]
       where
-        m' = (showLitString $ T.unpack m) ""
+        showArgs :: [(Identifier, T.Text)] -> T.Text
+        showArgs args' = T.intercalate ", " $ map showArg args'
+        showArg :: (Identifier, T.Text) -> T.Text
+        showArg (key, value) = [qq|{toCode key} = {literal value}|]
+        literal :: T.Text -> T.Text
+        literal s = [qq|"{(showLitString $ T.unpack s) ""}"|]
         showLitString :: String -> ShowS
         showLitString = foldr ((.) . showLitChar') id
         showLitChar' :: Char -> ShowS
         showLitChar' '"' = showString "\\\""
         showLitChar' c = C.showLitChar c
-    toCode Annotation {name = n, metadata = Nothing} = [qq|@{toCode n}|]
-
-fromTuple :: (Identifier, Maybe Metadata) -> Annotation
-fromTuple (name', meta') = Annotation { name = name', metadata = meta' }
 
 newtype AnnotationSet
   -- | The set of 'Annotation' values.
   -- Every annotation name has to be unique in the set.
-  = AnnotationSet { annotations :: M.Map Identifier (Maybe Metadata) }
+  = AnnotationSet { annotations :: M.Map Identifier AnnotationArgumentSet }
   deriving (Eq, Ord, Show)
 
 instance Construct AnnotationSet where
     toCode AnnotationSet {annotations = annotations'} =
-        T.concat [s | e <- M.assocs annotations'
-                    , fst e /= annotationDocsName
-                    , s <- [toCode $ fromTuple e, "\n"]]
+        T.concat [ s
+                 | (name', args) <- M.assocs annotations'
+                 , name' /= docsAnnotationName
+                 , s <- [toCode $ Annotation name' args, "\n"]
+                 ]

--- a/src/Nirum/Constructs/Docs.hs
+++ b/src/Nirum/Constructs/Docs.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Nirum.Constructs.Docs ( Docs (Docs)
-                             , annotationDocsName
+                             , docsAnnotationName
+                             , docsAnnotationParameter
                              , title
                              , toBlock
                              , toCode
@@ -16,8 +17,11 @@ import Nirum.Constructs (Construct (toCode))
 import Nirum.Constructs.Identifier (Identifier)
 import Nirum.Docs (Block (Document, Heading), parse)
 
-annotationDocsName :: Identifier
-annotationDocsName = "docs"
+docsAnnotationName :: Identifier
+docsAnnotationName = "docs"
+
+docsAnnotationParameter :: Identifier
+docsAnnotationParameter = "docs"
 
 -- | Docstring for constructs.
 newtype Docs = Docs T.Text deriving (Eq, Ord, Show)

--- a/test/Nirum/Constructs/ServiceSpec.hs
+++ b/test/Nirum/Constructs/ServiceSpec.hs
@@ -2,13 +2,10 @@
 module Nirum.Constructs.ServiceSpec where
 
 import Data.String.QQ (s)
+import Data.Map.Strict as Map (fromList)
 import Test.Hspec.Meta
 
-import Nirum.Constructs.Annotation ( Annotation (Annotation)
-                                   , empty
-                                   , fromList
-                                   , union
-                                   )
+import Nirum.Constructs.Annotation
 import Nirum.Constructs.Docs (toCode)
 import Nirum.Constructs.Service (Method (Method), Parameter (Parameter))
 import Nirum.Constructs.TypeExpression ( TypeExpression ( ListModifier
@@ -20,7 +17,10 @@ import Util (singleDocs)
 
 spec :: Spec
 spec = do
-    let Right methodAnno = fromList [Annotation "http-get" (Just "/ping/")]
+    let methodAnno = singleton $ Annotation "http" $ Map.fromList
+            [ ("method", "GET")
+            , ("path", "/ping/")
+            ]
     let docsAnno = singleDocs "docs..."
     describe "Parameter" $
         specify "toCode" $ do
@@ -36,7 +36,7 @@ spec = do
             toCode (Method "ping" [] "bool"
                            Nothing
                            methodAnno) `shouldBe`
-                "@http-get(\"/ping/\")\nbool ping (),"
+                "@http(method = \"GET\", path = \"/ping/\")\nbool ping (),"
             toCode (Method "ping" [] "bool"
                            Nothing
                            docsAnno) `shouldBe`
@@ -52,11 +52,12 @@ spec = do
             toCode (Method "ping" [] "bool"
                            Nothing
                            methodAnno) `shouldBe`
-                "@http-get(\"/ping/\")\nbool ping (),"
+                "@http(method = \"GET\", path = \"/ping/\")\nbool ping (),"
             toCode (Method "ping" [] "bool"
                            (Just "ping-error")
                            methodAnno) `shouldBe`
-                "@http-get(\"/ping/\")\nbool ping () throws ping-error,"
+                "@http(method = \"GET\", path = \"/ping/\")\n\
+                \bool ping () throws ping-error,"
             toCode (Method "get-user"
                            [Parameter "user-id" "uuid" empty]
                            (OptionModifier "user")
@@ -237,7 +238,7 @@ user? get-user (
                            (ListModifier "post")
                            (Just "search-posts-error")
                            (docsAnno `union` methodAnno)) `shouldBe` [s|
-@http-get("/ping/")
+@http(method = "GET", path = "/ping/")
 [post] search-posts (
   # docs...
   uuid blog-id,

--- a/test/Nirum/Constructs/TypeDeclarationSpec.hs
+++ b/test/Nirum/Constructs/TypeDeclarationSpec.hs
@@ -1,17 +1,13 @@
 {-# LANGUAGE OverloadedLists, QuasiQuotes #-}
 module Nirum.Constructs.TypeDeclarationSpec where
 
-import Data.Either (rights)
+
 import Data.String.QQ (s)
 import qualified Data.Text as T
 import Test.Hspec.Meta
 
 import Nirum.Constructs (Construct (toCode))
-import Nirum.Constructs.Annotation ( Annotation (Annotation)
-                                   , AnnotationSet
-                                   , fromList
-                                   , empty
-                                   )
+import Nirum.Constructs.Annotation hiding (docs, name)
 import Nirum.Constructs.Declaration (Declaration (name), docs)
 import Nirum.Constructs.DeclarationSet (DeclarationSet)
 import Nirum.Constructs.Service (Method (Method), Service (Service))
@@ -26,7 +22,7 @@ import Nirum.Constructs.TypeDeclaration ( EnumMember (EnumMember)
 import Util (singleDocs)
 
 barAnnotationSet :: AnnotationSet
-barAnnotationSet = head $ rights [fromList [Annotation "bar" (Just "baz")]]
+barAnnotationSet = singleton $ Annotation "bar" [("val", "baz")]
 
 spec :: Spec
 spec = do
@@ -131,9 +127,9 @@ record person (
                         , Tag "rectangle" rectangleFields empty
                         , Tag "none" [] empty
                         ]
-                union = UnionType tags'
+                union' = UnionType tags'
                 a = TypeDeclaration { typename = "shape"
-                                    , type' = union
+                                    , type' = union'
                                     , typeAnnotations = empty
                                     }
                 b = a { typeAnnotations = singleDocs "shape type" }
@@ -184,7 +180,7 @@ service ping-service (
     bool ping ()
 );|]
                 toCode annoDecl `shouldBe`
-                    "@bar(\"baz\")\nservice anno-service (bool ping ());"
+                    "@bar(val = \"baz\")\nservice anno-service (bool ping ());"
                 -- TODO: more tests
         context "Import" $ do
             let import' = Import ["foo", "bar"] "baz" empty


### PR DESCRIPTION
As #178 suggested, I made annotation arguments multiple.  To simplify the rule unnamed arguments became unsupported; thus every argument has its parameter name.  `@docs`, an internal annotation that represents docs comments, also have a parameter named `docs`.  Annotations without parentheses are equivalent to zero arguments.

Also wrote some docs about annotations.  I believe the docs is enough substitution of explanation for this pull request.