### PR TITLE
Several changes on RTTI metadata for Python target

### DIFF
--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -832,6 +832,9 @@ compileTypeDeclaration src
     tagCodes <- mapM (compileUnionTag src typename') $ toList tags
     let className = toClassName' typename'
         tagCodes' = T.intercalate "\n\n" tagCodes
+        tagClasses = T.intercalate ", " [ toClassName' tagName
+                                        | Tag tagName _ _ <- toList tags
+                                        ]
         enumMembers = toIndentedCodes
             (\ (t, b) -> [qq|$t = '{b}'|]) enumMembers' "\n        "
     importTypingForPython3
@@ -841,6 +844,10 @@ compileTypeDeclaration src
                             ]
     insertThirdPartyImportsA [ ( "nirum.constructs"
                                , [("name_dict_type", "NameDict")]
+                               )
+                             ]
+    insertThirdPartyImportsA [ ( "nirum.datastructures"
+                               , [("map_type", "Map")]
                                )
                              ]
     typeRepr <- typeReprCompiler
@@ -875,6 +882,11 @@ class $className({T.intercalate "," $ compileExtendClasses annotations}):
 
 
 $tagCodes'
+
+$className.__nirum_tag_classes__ = map_type(
+    (tcls.__nirum_tag__, tcls)
+    for tcls in [$tagClasses]
+)
             |]
   where
     enumMembers' :: [(T.Text, T.Text)]

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -505,6 +505,7 @@ class $className($parentClass):
     __slots__ = (
         $slots
     )
+    __nirum_type__ = 'union'
     __nirum_tag__ = $parentClass.Tag.{toAttributeName' typename'}
     __nirum_tag_names__ = name_dict_type([
         $nameMaps
@@ -630,6 +631,9 @@ compileTypeDeclaration src d@TypeDeclaration { typename = typename'
     return [qq|
 class $className(object):
 {compileDocstring "    " d}
+
+    __nirum_type__ = 'unboxed'
+
     @staticmethod
     def __nirum_get_inner_type__():
         return $itypeExpr
@@ -699,6 +703,11 @@ $memberNames
         {arg "value" "str"}
     ){ ret className }:
         return cls(value.replace('-', '_'))  # FIXME: validate input
+
+
+# Since enum.Enum doesn't allow to define non-member when the class is defined,
+# __nirum_type__ should be defined after the class is defined.
+$className.__nirum_type__ = 'enum'
 |]
   where
     memberKeywords :: [T.Text]
@@ -777,6 +786,7 @@ class $className(object):
     __slots__ = (
         $slots,
     )
+    __nirum_type__ = 'record'
     __nirum_record_behind_name__ = (
         '{I.toSnakeCaseText $ N.behindName typename'}'
     )
@@ -840,6 +850,7 @@ compileTypeDeclaration src
 class $className({T.intercalate "," $ compileExtendClasses annotations}):
 {compileDocstring "    " d}
 
+    __nirum_type__ = 'union'
     __nirum_union_behind_name__ = '{I.toSnakeCaseText $ N.behindName typename'}'
     __nirum_field_names__ = name_dict_type([$nameMaps])
 
@@ -919,6 +930,7 @@ compileTypeDeclaration
     return [qq|
 class $className(service_type):
 {compileDocstring "    " d}
+    __nirum_type__ = 'service'
     __nirum_schema_version__ = \'{SV.toText $ version metadata'}\'
     __nirum_service_methods__ = \{
         {methodMetadata'}

--- a/test/nirum_fixture/fixture/foo.nrm
+++ b/test/nirum_fixture/fixture/foo.nrm
@@ -21,9 +21,9 @@ enum eva-char = soryu-asuka-langley
               | katsuragi-misato
               | nagisa-kaworu
               ;
-enum duplicate-keyword = mro
-                       | no-mro
-                       ;
+
+enum reserved-keyword-enum = mro | no-mro;
+union reserved-keyword-union = mro | no-mro;
 
 record point1 (
     # Record docs.

--- a/test/python/primitive_test.py
+++ b/test/python/primitive_test.py
@@ -10,7 +10,7 @@ from fixture.foo import (CultureAgnosticName, Dog, DuplicateKeyword,
                          FloatUnbox, Gender, ImportedTypeUnbox, Irum,
                          Line, MixedName, Music, NullService,
                          Point1, Point2, Point3d, Pop, PingService, Product,
-                         Rnb, Run, Status, Stop, Way, WesternName)
+                         Rnb, RpcError, Run, Status, Stop, Way, WesternName)
 from fixture.foo.bar import PathUnbox, IntUnbox, Point
 from fixture.qux import Path, Name
 
@@ -299,5 +299,22 @@ def test_nirum_type():
     assert Status.__nirum_type__ == 'union'
     assert Run.__nirum_type__ == 'union'
     assert Stop.__nirum_type__ == 'union'
+    assert RpcError.__nirum_type__ == 'union'
     assert NullService.__nirum_type__ == 'service'
     assert PingService.__nirum_type__ == 'service'
+
+
+def test_nirum_tag_classes():
+    assert MixedName.__nirum_tag_classes__ == {
+        MixedName.Tag.western_name: WesternName,
+        MixedName.Tag.east_asian_name: EastAsianName,
+        MixedName.Tag.culture_agnostic_name: CultureAgnosticName,
+    }
+    assert Music.__nirum_tag_classes__ == {
+        Music.Tag.pop: Pop,
+        Music.Tag.rnb: Rnb,
+    }
+    assert Status.__nirum_tag_classes__ == {
+        Status.Tag.run: Run,
+        Status.Tag.stop: Stop,
+    }

--- a/test/python/primitive_test.py
+++ b/test/python/primitive_test.py
@@ -8,9 +8,9 @@ from six import PY3
 from fixture.foo import (CultureAgnosticName, Dog, DuplicateKeyword,
                          EastAsianName, EvaChar,
                          FloatUnbox, Gender, ImportedTypeUnbox, Irum,
-                         Line, MixedName, NullService,
+                         Line, MixedName, Music, NullService,
                          Point1, Point2, Point3d, Pop, PingService, Product,
-                         Rnb, Run, Stop, Way, WesternName)
+                         Rnb, Run, Status, Stop, Way, WesternName)
 from fixture.foo.bar import PathUnbox, IntUnbox, Point
 from fixture.qux import Path, Name
 
@@ -277,3 +277,27 @@ def test_enum_duplicate_member_name():
             DuplicateKeyword.no_mro)
     assert DuplicateKeyword.mro_.__nirum_serialize__() == 'mro'
     assert DuplicateKeyword.no_mro.__nirum_serialize__() == 'no_mro'
+
+
+def test_nirum_type():
+    assert FloatUnbox.__nirum_type__ == 'unboxed'
+    assert Way.__nirum_type__ == 'unboxed'
+    assert Gender.__nirum_type__ == 'enum'
+    assert EvaChar.__nirum_type__ == 'enum'
+    assert Point1.__nirum_type__ == 'record'
+    assert Point2.__nirum_type__ == 'record'
+    assert Point3d.__nirum_type__ == 'record'
+    assert Line.__nirum_type__ == 'record'
+    assert Product.__nirum_type__ == 'record'
+    assert MixedName.__nirum_type__ == 'union'
+    assert WesternName.__nirum_type__ == 'union'
+    assert EastAsianName.__nirum_type__ == 'union'
+    assert CultureAgnosticName.__nirum_type__ == 'union'
+    assert Music.__nirum_type__ == 'union'
+    assert Pop.__nirum_type__ == 'union'
+    assert Rnb.__nirum_type__ == 'union'
+    assert Status.__nirum_type__ == 'union'
+    assert Run.__nirum_type__ == 'union'
+    assert Stop.__nirum_type__ == 'union'
+    assert NullService.__nirum_type__ == 'service'
+    assert PingService.__nirum_type__ == 'service'

--- a/test/python/primitive_test.py
+++ b/test/python/primitive_test.py
@@ -5,11 +5,12 @@ from pytest import raises
 from nirum.service import Service
 from six import PY3
 
-from fixture.foo import (CultureAgnosticName, Dog, DuplicateKeyword,
+from fixture.foo import (CultureAgnosticName, Dog,
                          EastAsianName, EvaChar,
                          FloatUnbox, Gender, ImportedTypeUnbox, Irum,
-                         Line, MixedName, Music, NullService,
+                         Line, MixedName, Mro, Music, NoMro, NullService,
                          Point1, Point2, Point3d, Pop, PingService, Product,
+                         ReservedKeywordEnum, ReservedKeywordUnion,
                          Rnb, RpcError, Run, Status, Stop, Way, WesternName)
 from fixture.foo.bar import PathUnbox, IntUnbox, Point
 from fixture.qux import Path, Name
@@ -268,15 +269,26 @@ def test_service():
         PingService().ping(wrongkwd=u'a')
 
 
-def test_enum_duplicate_member_name():
-    assert hasattr(DuplicateKeyword, 'mro_')
-    assert hasattr(DuplicateKeyword, 'no_mro')
-    assert (DuplicateKeyword.__nirum_deserialize__(u'mro') ==
-            DuplicateKeyword.mro_)
-    assert (DuplicateKeyword.__nirum_deserialize__(u'no-mro') ==
-            DuplicateKeyword.no_mro)
-    assert DuplicateKeyword.mro_.__nirum_serialize__() == 'mro'
-    assert DuplicateKeyword.no_mro.__nirum_serialize__() == 'no_mro'
+def test_enum_reserved_keyword_for_member():
+    assert hasattr(ReservedKeywordEnum, 'mro_')
+    assert hasattr(ReservedKeywordEnum, 'no_mro')
+    assert (ReservedKeywordEnum.__nirum_deserialize__(u'mro') ==
+            ReservedKeywordEnum.mro_)
+    assert (ReservedKeywordEnum.__nirum_deserialize__(u'no-mro') ==
+            ReservedKeywordEnum.no_mro)
+    assert ReservedKeywordEnum.mro_.__nirum_serialize__() == 'mro'
+    assert ReservedKeywordEnum.no_mro.__nirum_serialize__() == 'no_mro'
+
+
+def test_union_reserved_keyword_for_tag():
+    assert ReservedKeywordUnion.Tag.mro_.value == 'mro'
+    assert ReservedKeywordUnion.Tag.no_mro.value == 'no_mro'
+    assert Mro.__nirum_tag__ is ReservedKeywordUnion.Tag.mro_
+    assert NoMro.__nirum_tag__ is ReservedKeywordUnion.Tag.no_mro
+    assert ReservedKeywordUnion.__nirum_tag_classes__ == {
+        ReservedKeywordUnion.Tag.mro_: Mro,
+        ReservedKeywordUnion.Tag.no_mro: NoMro,
+    }
 
 
 def test_nirum_type():


### PR DESCRIPTION
- As I suggested from <https://github.com/spoqa/nirum-python/issues/34#issuecomment-247835731>, now generated Python classes have `__nirum_type__` attribute which contains one of `'unboxed'`/`'enum'`/`'record'`/`'union'`/`'service'`.  The future versions of Python runtime library would be able to utilize this rather than diagnostics using `isinstance()`/`hasattr()` queries. See also examples on `test_nirum_type()`.

- Also as I suggested from the same comment above, now union classes have an immutable map named `__nirum_tags__` that keys are tags and values are class objects.  See also examples on `test_nirum_tag_classes()`.

- Since the bug #185 was also applicable to union tag enums, also fixed it.  See also `test_union_reserved_keyword_for_tag()` to reproduce the bug.