### PR TITLE
Qualify tag classes under type classes

### DIFF
--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -545,6 +545,11 @@ class $className($parentClass):
 
     def __hash__(self){ ret "int" }:
         return hash($hashTuple)
+
+
+$parentClass.$className = $className
+if hasattr($parentClass, '__qualname__'):
+    $className.__qualname__ = $parentClass.__qualname__ + '.{className}'
 |]
 compilePrimitiveType :: PrimitiveTypeIdentifier -> CodeGen Code
 compilePrimitiveType primitiveTypeIdentifier = do

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -485,7 +485,6 @@ compileUnionTag source parentname d@(Tag typename' fields _) = do
         [ ("nirum.validate", [("validate_union_type", "validate_union_type")])
         , ("nirum.constructs", [("name_dict_type", "NameDict")])
         ]
-    typeRepr <- typeReprCompiler
     arg <- parameterCompiler
     ret <- returnCompiler
     pyVer <- getPythonVersion
@@ -528,10 +527,11 @@ class $className($parentClass):
     { inits :: T.Text }
 
     def __repr__(self){ ret "str" }:
-        return '\{0\}(\{1\})'.format(
-            {typeRepr "type(self)"},
-            ', '.join('\{\}=\{\}'.format(attr, getattr(self, attr))
-                      for attr in self.__slots__)
+        return (
+            $parentClass.__module__ + '.$parentClass.$className(' +
+            ', '.join('\{0\}=\{1!r\}'.format(attr, getattr(self, attr))
+                      for attr in self.__slots__) +
+            ')'
         )
 
     def __eq__(self, other){ ret "bool" }:

--- a/test/python/primitive_test.py
+++ b/test/python/primitive_test.py
@@ -203,6 +203,16 @@ def test_union():
                                        last_name=u'wrong')
     assert hash(WesternName(first_name=u'foo', middle_name=u'bar',
                             last_name=u'baz'))
+    if PY3:
+        assert repr(western_name) == (
+            "fixture.foo.MixedName.WesternName(first_name='foo', "
+            "middle_name='bar', last_name='baz')"
+        )
+    else:
+        assert repr(western_name) == (
+            "fixture.foo.MixedName.WesternName(first_name=u'foo', "
+            "middle_name=u'bar', last_name=u'baz')"
+        )
     assert EastAsianName is MixedName.EastAsianName
     assert isinstance(EastAsianName, type)
     assert issubclass(EastAsianName, MixedName)

--- a/test/python/primitive_test.py
+++ b/test/python/primitive_test.py
@@ -174,6 +174,7 @@ def test_union():
     assert MixedName.Tag.western_name.value == 'western_name'
     assert MixedName.Tag.east_asian_name.value == 'east_asian_name'
     assert MixedName.Tag.culture_agnostic_name.value == 'culture_agnostic_name'
+    assert WesternName is MixedName.WesternName  # alias
     assert isinstance(WesternName, type)
     assert issubclass(WesternName, MixedName)
     with raises(NotImplementedError):
@@ -202,6 +203,7 @@ def test_union():
                                        last_name=u'wrong')
     assert hash(WesternName(first_name=u'foo', middle_name=u'bar',
                             last_name=u'baz'))
+    assert EastAsianName is MixedName.EastAsianName
     assert isinstance(EastAsianName, type)
     assert issubclass(EastAsianName, MixedName)
     east_asian_name = EastAsianName(family_name=u'foo', given_name=u'baz')
@@ -219,6 +221,7 @@ def test_union():
         EastAsianName(family_name=1, given_name=u'baz')
     with raises(TypeError):
         EastAsianName(family_name=u'foo', given_name=2)
+    assert CultureAgnosticName is MixedName.CultureAgnosticName
     assert isinstance(CultureAgnosticName, type)
     assert issubclass(CultureAgnosticName, MixedName)
     agnostic_name = CultureAgnosticName(fullname=u'foobar')


### PR DESCRIPTION
Implemented an essential part of the suggestion made by #68.  Now the canonical name of every generated tag class is under its union class (e.g. `Rectangle` → `Shape.Rectangle`).  As it's still undetermined whether or not to leave unqualified name, I remained it as it had been for backward compatibility.