### PR TITLE
Compile service method annotation

### DIFF
--- a/examples/pdf-service.nrm
+++ b/examples/pdf-service.nrm
@@ -1,4 +1,5 @@
 @error
+@http-status(code="400")
 union markdown-parse-error = symbol-error | syntax-error (text reason);
 
 type html = text;
@@ -6,16 +7,19 @@ type html = text;
 service pdf-service (
     # A microservice which renders a PDF from the given URI or HTML.
 
+    @http-resource(method="GET", path="/pdf/{uri}")
     binary render-uri (
         # Renders a PDF from the given URI.
         uri uri,
     ),
 
+    @http-resource(method="POST", path="/pdf/")
     binary render-html (
         # Renders a PDF from the given HTML text.
         html html,
     ),
 
+    @http-resource(method="POST", path="/pdf/")
     binary render-md (
         # Renders a PDF from the given HTML text.
         text md,

--- a/lint.sh
+++ b/lint.sh
@@ -17,7 +17,7 @@ EOF
   chmod +x .git/hooks/pre-commit
 fi
 
-stack test hlint
+stack test :hlint
 if [[ "$(stack exec scan -- -v)" = "" ]]; then
   stack install scan
 fi

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -1098,12 +1098,13 @@ class {className}_Client($className):
     compileAnnotation :: I.Identifier -> A.AnnotationArgumentSet -> T.Text
     compileAnnotation ident annoArgument =
         toKeyItem ident $
-            wrapMap $ T.intercalate "," $ [ (toKeyStr ident' value) :: T.Text
-                                | (ident', value) <- M.toList annoArgument
-                                ]
+            wrapMap $ T.intercalate ","
+                [ toKeyStr ident' value :: T.Text
+                | (ident', value) <- M.toList annoArgument
+                ]
       where
         escapeSingle :: T.Text -> T.Text
-        escapeSingle = T.strip . (T.replace "'" "\\'")
+        escapeSingle = T.strip . T.replace "'" "\\'"
         toKeyStr :: I.Identifier -> T.Text -> T.Text
         toKeyStr k v =
             [qq|'{toAttributeName k}': '''{escapeSingle v}'''|]
@@ -1114,13 +1115,12 @@ class {className}_Client($className):
         toKeyItem (N.facialName mName) $ wrapMap annotationDict
       where
         annotationDict :: T.Text
-        annotationDict = T.intercalate "," $
-            [ (compileAnnotation ident annoArgSet) :: T.Text
-            | (ident, annoArgSet)
-            <- M.toList $ A.annotations annoSet
+        annotationDict = T.intercalate ","
+            [ compileAnnotation ident annoArgSet :: T.Text
+            | (ident, annoArgSet) <- M.toList $ A.annotations annoSet
             ]
     methodAnnotations' :: T.Text
-    methodAnnotations' = wrapMap $ commaNl $ map compileMethodAnnotation $
+    methodAnnotations' = wrapMap $ commaNl $ map compileMethodAnnotation
         methodList
 
 compileTypeDeclaration _ Import {} =

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -81,6 +81,7 @@ import Nirum.Constructs.Name (Name (Name))
 import qualified Nirum.Constructs.Name as N
 import Nirum.Constructs.Service ( Method ( Method
                                          , errorType
+                                         , methodAnnotations
                                          , methodName
                                          , parameters
                                          , returnType
@@ -955,6 +956,7 @@ class $className(service_type):
     __nirum_method_names__ = name_dict_type([
         $methodNameMap
     ])
+    __nirum_method_annotations__ = $methodAnnotations'
 
     @staticmethod
     def __nirum_method_error_types__(k, d=None):
@@ -1033,6 +1035,8 @@ class {className}_Client($className):
             '_names': name_dict_type([{paramNameMap params'}]),
             {paramMetadata'}
         \}|]
+    methodList :: [Method]
+    methodList = toList methods
     compileParameterMetadata :: Parameter -> CodeGen Code
     compileParameterMetadata (Parameter pName pType _) = do
         let pName' = toAttributeName' pName
@@ -1041,7 +1045,7 @@ class {className}_Client($className):
     methodNameMap :: T.Text
     methodNameMap = toIndentedCodes
         toNamePair
-        [mName | Method { methodName = mName } <- toList methods]
+        [mName | Method { methodName = mName } <- methodList]
         ",\n        "
     paramNameMap :: [Parameter] -> T.Text
     paramNameMap params = toIndentedCodes
@@ -1075,7 +1079,7 @@ class {className}_Client($className):
             payload=\{{commaNl payloadArguments}\},
             # FIXME Give annotations.
             service_annotations=\{\},
-            method_annotations=\{\},
+            method_annotations=self.__nirum_method_annotations__,
             parameter_annotations=\{\}
         )
         if successful:
@@ -1087,6 +1091,37 @@ class {className}_Client($className):
             return result
         raise result
 |]
+    toKeyItem :: I.Identifier -> T.Text -> T.Text
+    toKeyItem ident v = [qq|'{toAttributeName ident}': {v}|]
+    wrapMap :: T.Text -> T.Text
+    wrapMap items = [qq|map_type(\{$items\})|]
+    compileAnnotation :: I.Identifier -> A.AnnotationArgumentSet -> T.Text
+    compileAnnotation ident annoArgument =
+        toKeyItem ident $
+            wrapMap $ T.intercalate "," $ [ (toKeyStr ident' value) :: T.Text
+                                | (ident', value) <- M.toList annoArgument
+                                ]
+      where
+        escapeSingle :: T.Text -> T.Text
+        escapeSingle = T.strip . (T.replace "'" "\\'")
+        toKeyStr :: I.Identifier -> T.Text -> T.Text
+        toKeyStr k v =
+            [qq|'{toAttributeName k}': '''{escapeSingle v}'''|]
+    compileMethodAnnotation :: Method -> T.Text
+    compileMethodAnnotation Method { methodName = mName
+                                   , methodAnnotations = annoSet
+                                   } =
+        toKeyItem (N.facialName mName) $ wrapMap annotationDict
+      where
+        annotationDict :: T.Text
+        annotationDict = T.intercalate "," $
+            [ (compileAnnotation ident annoArgSet) :: T.Text
+            | (ident, annoArgSet)
+            <- M.toList $ A.annotations annoSet
+            ]
+    methodAnnotations' :: T.Text
+    methodAnnotations' = wrapMap $ commaNl $ map compileMethodAnnotation $
+        methodList
 
 compileTypeDeclaration _ Import {} =
     return ""  -- Nothing to compile

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -942,6 +942,7 @@ compileTypeDeclaration
                             ]
     insertThirdPartyImportsA
         [ ("nirum.constructs", [("name_dict_type", "NameDict")])
+        , ("nirum.datastructures", [(nirumMapName, "Map")])
         , ("nirum.service", [("service_type", "Service")])
         , ("nirum.transport", [("transport_type", "Transport")])
         ]
@@ -984,6 +985,8 @@ class {className}_Client($className):
     {clientMethods'}
 |]
   where
+    nirumMapName :: T.Text
+    nirumMapName = "map_type"
     className :: T.Text
     className = toClassName' name'
     commaNl :: [T.Text] -> T.Text
@@ -1094,7 +1097,7 @@ class {className}_Client($className):
     toKeyItem :: I.Identifier -> T.Text -> T.Text
     toKeyItem ident v = [qq|'{toAttributeName ident}': {v}|]
     wrapMap :: T.Text -> T.Text
-    wrapMap items = [qq|map_type(\{$items\})|]
+    wrapMap items = [qq|$nirumMapName(\{$items\})|]
     compileAnnotation :: I.Identifier -> A.AnnotationArgumentSet -> T.Text
     compileAnnotation ident annoArgument =
         toKeyItem ident $

--- a/test/nirum_fixture/fixture/foo.nrm
+++ b/test/nirum_fixture/fixture/foo.nrm
@@ -88,6 +88,9 @@ union rpc-error = connection-lose-error
 
 service ping-service (
     # Service docs.
+
+    @http-resource(method="GET", path="/ping")
+    @quote(single="'", triple="'''")
     bool ping (
         # Method docs.
         text nonce,

--- a/test/python/annotation_test.py
+++ b/test/python/annotation_test.py
@@ -1,5 +1,15 @@
-from fixture.foo import RpcError
+from fixture.foo import PingService, RpcError
+from nirum.datastructures import Map
 
 
 def test_annotation_as_error():
     assert issubclass(RpcError, Exception)
+
+
+def test_service_method_annotation_metadata():
+    expect = Map({
+        'docs': Map({'docs': 'Method docs.'}),
+        'http_resource': Map({'method': 'GET', 'path': '/ping'}),
+        'quote': Map({'single': "'", 'triple': "'''"})
+    })
+    assert PingService.__nirum_method_annotations__['ping'] == expect


### PR DESCRIPTION
Since we need metadata of annotations on service class to route HTTP paths, i added `__nirum_method_annotations__` property.

`__nirum_method_annotations__` contain metadata of method annotations as nirum.datastaructures.Map type because it have to be immutable data.