### PR TITLE
Move BoundModule and functions for it to a separated module

### DIFF
--- a/src/Nirum/Targets/Docs.hs
+++ b/src/Nirum/Targets/Docs.hs
@@ -41,12 +41,7 @@ import Nirum.Docs ( Block (Heading)
                   , filterReferences
                   )
 import Nirum.Docs.Html (render, renderInlines)
-import Nirum.Package ( BoundModule (boundPackage, modulePath)
-                     , Package (Package, metadata, modules)
-                     , resolveBoundModule
-                     , resolveModule
-                     , types
-                     )
+import Nirum.Package
 import Nirum.Package.Metadata ( Author (Author, email, name, uri)
                               , Metadata (authors)
                               , Target ( CompileError
@@ -59,6 +54,7 @@ import Nirum.Package.Metadata ( Author (Author, email, name, uri)
                                        )
                               )
 import qualified Nirum.Package.ModuleSet as MS
+import Nirum.TypeInstance.BoundModule
 import Nirum.Version (versionText)
 
 data Docs = Docs deriving (Eq, Ord, Show)
@@ -127,7 +123,7 @@ module' docsModule = layout pkg depth path $ [shamlet|
     path = toCode docsModulePath
     types' :: [(Identifier, TD.TypeDeclaration)]
     types' = [ (facialName $ DE.name decl, decl)
-             | decl <- DES.toList $ types docsModule
+             | decl <- DES.toList $ boundTypes docsModule
              , case decl of
                     TD.Import {} -> False
                     _ -> True

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -109,13 +109,7 @@ import Nirum.Constructs.TypeExpression ( TypeExpression ( ListModifier
                                                         )
                                        )
 import Nirum.Docs.ReStructuredText (ReStructuredText, render)
-import Nirum.Package ( BoundModule
-                     , Package (Package, metadata, modules)
-                     , TypeLookup (Imported, Local, Missing)
-                     , lookupType
-                     , resolveBoundModule
-                     , types
-                     )
+import Nirum.Package hiding (target)
 import Nirum.Package.Metadata ( Author (Author, name, email)
                               , Metadata ( Metadata
                                          , authors
@@ -144,6 +138,7 @@ import Nirum.Package.Metadata ( Author (Author, name, email)
                               )
 import qualified Nirum.Package.ModuleSet as MS
 import qualified Nirum.Package.Metadata as MD
+import Nirum.TypeInstance.BoundModule
 
 minimumRuntime :: SV.Version
 minimumRuntime = SV.version 0 6 0 [] []
@@ -1093,7 +1088,7 @@ compileTypeDeclaration _ Import {} =
 
 compileModuleBody :: Source -> CodeGen Code
 compileModuleBody src@Source { sourceModule = boundModule } = do
-    let types' = types boundModule
+    let types' = boundTypes boundModule
     typeCodes <- mapM (compileTypeDeclaration src) $ toList types'
     return $ T.intercalate "\n\n" typeCodes
 

--- a/src/Nirum/TypeInstance/BoundModule.hs
+++ b/src/Nirum/TypeInstance/BoundModule.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE RankNTypes, StandaloneDeriving #-}
+module Nirum.TypeInstance.BoundModule
+    ( BoundModule (boundPackage, modulePath)
+    , TypeLookup (..)
+    , boundTypes
+    , findInBoundModule
+    , lookupType
+    , resolveBoundModule
+    ) where
+
+import Nirum.Constructs.Declaration
+import Nirum.Constructs.DeclarationSet as DS
+import Nirum.Constructs.Identifier
+import Nirum.Constructs.Module
+import Nirum.Constructs.ModulePath
+import Nirum.Constructs.TypeDeclaration as TypeDeclaration hiding (modulePath)
+import Nirum.Package
+import Nirum.Package.Metadata
+import qualified Nirum.Package.ModuleSet as ModuleSet
+
+data BoundModule t = BoundModule
+    { boundPackage :: Target t => Package t
+    , modulePath :: ModulePath
+    }
+
+deriving instance (Eq t, Target t) => Eq (BoundModule t)
+deriving instance (Ord t, Target t) => Ord (BoundModule t)
+deriving instance (Show t, Target t) => Show (BoundModule t)
+
+resolveBoundModule :: ModulePath -> Package t -> Maybe (BoundModule t)
+resolveBoundModule path' package =
+    case resolveModule path' package of
+        Just _ -> Just $ BoundModule package path'
+        Nothing -> Nothing
+
+findInBoundModule :: Target t => (Module -> a) -> a -> BoundModule t -> a
+findInBoundModule valueWhenExist valueWhenNotExist
+                  BoundModule { boundPackage = Package { modules = ms }
+                              , modulePath = path'
+                              } =
+    case ModuleSet.lookup path' ms of
+        Nothing -> valueWhenNotExist
+        Just mod' -> valueWhenExist mod'
+
+boundTypes :: Target t => BoundModule t -> DeclarationSet TypeDeclaration
+boundTypes = findInBoundModule types DS.empty
+
+data TypeLookup = Missing
+                | Local Type
+                | Imported ModulePath Type
+                deriving (Eq, Ord, Show)
+
+lookupType :: Target t => Identifier -> BoundModule t -> TypeLookup
+lookupType identifier boundModule =
+    case DS.lookup identifier (boundTypes boundModule) of
+        Nothing -> toType coreModulePath
+            (DS.lookup identifier $ types coreModule)
+        Just TypeDeclaration { type' = t } -> Local t
+        Just (Import path' _ _) ->
+            case resolveModule path' (boundPackage boundModule) of
+                Nothing -> Missing
+                Just (Module decls _) ->
+                    toType path' (DS.lookup identifier decls)
+        Just ServiceDeclaration {} -> Missing
+  where
+    toType :: ModulePath -> Maybe TypeDeclaration -> TypeLookup
+    toType mp (Just TypeDeclaration { type' = t }) = Imported mp t
+    toType _ _ = Missing
+
+instance Target t => Documented (BoundModule t) where
+    docs = findInBoundModule Nirum.Constructs.Module.docs Nothing

--- a/test/Nirum/CodeBuilderSpec.hs
+++ b/test/Nirum/CodeBuilderSpec.hs
@@ -16,9 +16,9 @@ import qualified Nirum.Constructs.DeclarationSet as DS
 import Nirum.Constructs.Module (Module (..))
 import Nirum.Constructs.ModulePath (ModulePath (..))
 import qualified Nirum.Constructs.TypeDeclaration as TD
-import Nirum.Package (TypeLookup (..))
 import Nirum.Package.Metadata (Metadata (..), Package (..), Target (..))
 import qualified Nirum.Package.ModuleSet as MS
+import Nirum.TypeInstance.BoundModule hiding (lookupType)
 
 
 emptyModule :: Module

--- a/test/Nirum/Targets/PythonSpec.hs
+++ b/test/Nirum/Targets/PythonSpec.hs
@@ -35,7 +35,7 @@ import Nirum.Constructs.TypeExpression ( TypeExpression ( ListModifier
                                                         , TypeIdentifier
                                                         )
                                        )
-import Nirum.Package (Package (metadata, modules), resolveBoundModule)
+import Nirum.Package hiding (target)
 import Nirum.Package.Metadata ( Author (Author, email, name, uri)
                               , Metadata ( Metadata
                                          , authors
@@ -82,6 +82,7 @@ import Nirum.Targets.Python ( Source (Source)
                             , toNamePair
                             , unionInstallRequires
                             )
+import Nirum.TypeInstance.BoundModule
 
 codeGen :: a -> CodeGen a
 codeGen = return

--- a/test/Nirum/TypeInstance/BoundModuleSpec.hs
+++ b/test/Nirum/TypeInstance/BoundModuleSpec.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Nirum.TypeInstance.BoundModuleSpec where
+
+import Data.Proxy
+
+import Test.Hspec.Meta
+import Text.InterpolatedString.Perl6 (qq)
+
+import Nirum.Constructs.Annotation hiding (docs)
+import Nirum.Constructs.Declaration
+import Nirum.Constructs.Module hiding (docs)
+import Nirum.Constructs.TypeDeclaration hiding (modulePath)
+import Nirum.Package.Metadata
+import Nirum.Package.MetadataSpec
+import Nirum.PackageSpec (createValidPackage)
+import Nirum.Targets.Python (Python (Python), minimumRuntime)
+import Nirum.TypeInstance.BoundModule
+
+spec :: Spec
+spec = do
+    testPackage (Python "nirum-examples" minimumRuntime [])
+    testPackage DummyTarget
+
+testPackage :: forall t . Target t => t -> Spec
+testPackage target' = do
+    let targetName' = targetName (Proxy :: Proxy t)
+        validPackage = createValidPackage target'
+    specify "resolveBoundModule" $ do
+        let Just bm = resolveBoundModule ["foo"] validPackage
+        boundPackage bm `shouldBe` validPackage
+        modulePath bm `shouldBe` ["foo"]
+        resolveBoundModule ["baz"] validPackage `shouldBe` Nothing
+    describe [qq|BoundModule (target: $targetName')|] $ do
+        let Just bm = resolveBoundModule ["foo", "bar"] validPackage
+            Just abc = resolveBoundModule ["abc"] validPackage
+            Just xyz = resolveBoundModule ["xyz"] validPackage
+        specify "docs" $ do
+            docs bm `shouldBe` Just "foo.bar"
+            let Just bm' = resolveBoundModule ["foo"] validPackage
+            docs bm' `shouldBe` Just "foo"
+        specify "boundTypes" $ do
+            boundTypes bm `shouldBe` []
+            boundTypes abc `shouldBe` [TypeDeclaration "a" (Alias "text") empty]
+            boundTypes xyz `shouldBe`
+                [ Import ["abc"] "a" empty
+                , TypeDeclaration "x" (Alias "text") empty
+                ]
+        specify "lookupType" $ do
+            lookupType "a" bm `shouldBe` Missing
+            lookupType "a" abc `shouldBe` Local (Alias "text")
+            lookupType "a" xyz `shouldBe` Imported ["abc"] (Alias "text")
+            lookupType "x" bm `shouldBe` Missing
+            lookupType "x" abc `shouldBe` Missing
+            lookupType "x" xyz `shouldBe` Local (Alias "text")
+            lookupType "text" bm `shouldBe`
+                Imported coreModulePath (PrimitiveType Text String)
+            lookupType "text" abc `shouldBe` lookupType "text" bm
+            lookupType "text" xyz `shouldBe` lookupType "text" bm


### PR DESCRIPTION
`BoundModule` and functions dealing with it get moved to a separated module named `Nirum.TypeInstance.BoundModule` which is its own.

In the later pull requests, I'm going to define some intermediate representation for types (which already evaluated every `TypeExpression` of them) in the `Nirum.TypeInstance` module.