### PR TITLE
Make annotation argument values able to contain Unicode characters

### DIFF
--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -1105,7 +1105,7 @@ class {className}_Client($className):
         escapeSingle = T.strip . T.replace "'" "\\'"
         toKeyStr :: I.Identifier -> T.Text -> T.Text
         toKeyStr k v =
-            [qq|'{toAttributeName k}': '''{escapeSingle v}'''|]
+            [qq|'{toAttributeName k}': u'''{escapeSingle v}'''|]
     compileMethodAnnotation :: Method -> T.Text
     compileMethodAnnotation Method { methodName = mName
                                    , methodAnnotations = annoSet

--- a/test/nirum_fixture/fixture/foo.nrm
+++ b/test/nirum_fixture/fixture/foo.nrm
@@ -91,6 +91,7 @@ service ping-service (
 
     @http-resource(method="GET", path="/ping")
     @quote(single="'", triple="'''")
+    @unicode(unicode="유니코드")
     bool ping (
         # Method docs.
         text nonce,

--- a/test/python/annotation_test.py
+++ b/test/python/annotation_test.py
@@ -8,8 +8,9 @@ def test_annotation_as_error():
 
 def test_service_method_annotation_metadata():
     expect = Map({
-        'docs': Map({'docs': 'Method docs.'}),
-        'http_resource': Map({'method': 'GET', 'path': '/ping'}),
-        'quote': Map({'single': "'", 'triple': "'''"})
+        'docs': Map({'docs': u'Method docs.'}),
+        'http_resource': Map({'method': u'GET', 'path': u'/ping'}),
+        'quote': Map({'single': u"'", 'triple': u"'''"}),
+        'unicode': Map({'unicode': u'\uc720\ub2c8\ucf54\ub4dc'}),
     })
     assert PingService.__nirum_method_annotations__['ping'] == expect


### PR DESCRIPTION
Unlike annotation names or annotation parameter names, annotation argument values should be able to contain non-ASCII Unicode characters.  This fixes the Python target to correctly translate annotation argument values to Unicode string literals instead of byte string literals.