### PR TITLE
Runtime free serializers

### DIFF
--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -1184,7 +1184,10 @@ class {className}_Client($className):
             result_type = $rtypeExpr
         else:
             $errorCode
-        result = deserialize_meta(result_type, serialized)
+        if result_type is None:
+            result = None
+        else:
+            result = deserialize_meta(result_type, serialized)
         if successful:
             return result
         raise result

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -1033,7 +1033,6 @@ compileTypeDeclaration
     ret <- returnCompiler
     insertStandardImport "json"
     insertThirdPartyImports [ ("nirum.deserialize", ["deserialize_meta"])
-                            , ("nirum.serialize", ["serialize_meta"])
                             ]
     insertThirdPartyImportsA
         [ ("nirum.constructs", [("name_dict_type", "NameDict")])
@@ -1149,10 +1148,10 @@ class {className}_Client($className):
     paramNameMap params = toIndentedCodes
         toNamePair [pName | Parameter pName _ _ <- params] ",\n        "
     compileClientPayload :: Parameter -> CodeGen Code
-    compileClientPayload (Parameter pName _ _) = do
+    compileClientPayload (Parameter pName pt _) = do
         let pName' = toAttributeName' pName
         return [qq|'{I.toSnakeCaseText $ N.behindName pName}':
-                   serialize_meta({pName'})|]
+                   ({compileSerializer src pt pName'})|]
     compileClientMethod :: Method -> CodeGen Code
     compileClientMethod Method { methodName = mName
                                , parameters = params

--- a/test/nirum_fixture/fixture/foo.nrm
+++ b/test/nirum_fixture/fixture/foo.nrm
@@ -121,3 +121,8 @@ record product (
 union animal = cat
              | dog (text name, text? kind, int64 age, int64? weight)
              ;
+
+service sample-service (
+    sample-method (animal a, product b/bb, gender c, way d/dd,
+                   uuid e, binary f/ff, bigint g, text h/hh),
+);

--- a/test/python/service_test.py
+++ b/test/python/service_test.py
@@ -1,4 +1,9 @@
-from fixture.foo import PingService, RpcError
+import uuid
+
+from nirum.transport import Transport
+
+from fixture.foo import (Dog, Gender, PingService, Product, RpcError,
+                         SampleService_Client, Way)
 
 
 def test_throws_error():
@@ -14,3 +19,67 @@ def test_no_return_method():
     assert error_types('no_return_method') is None
     assert methods['no_return_method2']['_return']() is None
     assert error_types('no_return_method2') is RpcError
+
+
+class DumbTransport(Transport):
+
+    def __init__(self):
+        self.calls = []
+
+    def call(self,
+             method_name,
+             payload,
+             service_annotations,
+             method_annotations,
+             parameter_annotations):
+        self.calls.append((
+            method_name,
+            payload,
+            service_annotations,
+            method_annotations,
+            parameter_annotations,
+        ))
+        return True, None
+
+    @property
+    def latest_call(self):
+        return self.calls[-1]
+
+
+def test_service_client_payload_serialization():
+    t = DumbTransport()
+    c = SampleService_Client(t)
+    c.sample_method(
+        a=Dog(name=u'Dog.name', age=3),
+        b=Product(name=u'Product.name', sale=False),
+        c=Gender.female,
+        d=Way(u'way/path/text'),
+        e=uuid.UUID('F7DB93E3-731E-48EF-80A2-CAC81E02F1AE'),
+        f=b'binary data',
+        g=1234,
+        h=u'text data'
+    )
+    assert t.latest_call[0] == 'sample_method'
+    assert t.latest_call[1] == {
+        'a': {
+            '_type': 'animal',
+            '_tag': 'dog',
+            'name': 'Dog.name',
+            'kind': None,
+            'age': 3,
+            'weight': None,
+        },
+        'bb': {
+            '_type': 'product',
+            'name': 'Product.name',
+            'price': None,
+            'sale': False,
+            'url': None,
+        },
+        'c': 'yeoseong',
+        'dd': 'way/path/text',
+        'e': 'f7db93e3-731e-48ef-80a2-cac81e02f1ae',
+        'ff': u'YmluYXJ5IGRhdGE=',
+        'g': 1234,
+        'hh': 'text data',
+    }

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
 commands =
     pip install -f {distdir} -e {distdir}/nirum_fixture
     flake8 test/python
-    pytest -vv -s test/python
+    pytest {posargs:--ff -vv -s} test/python
 
 [testenv:buildfixture]
 skip_install = true


### PR DESCRIPTION
This patch makes Python target to generate standalone serializers for generated types so that these are independent from `nirum.serialize.serialize_*()` functions implemented by nirum-python runtime library.

Service clients also became free from `serialize_meta()` function.