### PR TITLE
Fix optional types serializer to be null-safe

### DIFF
--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -643,7 +643,8 @@ compileSerializer Source { sourceModule = boundModule } =
 
 compileSerializer' :: BoundModule Python -> TypeExpression -> Code -> Code
 compileSerializer' mod' (OptionModifier typeExpr) pythonVar =
-    compileSerializer' mod' typeExpr pythonVar
+    [qq|(None if ($pythonVar) is None
+              else ({compileSerializer' mod' typeExpr pythonVar}))|]
 compileSerializer' mod' (SetModifier typeExpr) pythonVar =
     compileSerializer' mod' (ListModifier typeExpr) pythonVar
 compileSerializer' mod' (ListModifier typeExpr) pythonVar =

--- a/test/nirum_fixture/fixture/foo.nrm
+++ b/test/nirum_fixture/fixture/foo.nrm
@@ -43,6 +43,9 @@ record point3d (
 record line (
     bigint length,
 );
+record record-with-optional-record-field (
+    point1? f,
+);
 
 record import-typing (
     // see also: https://github.com/spoqa/nirum/issues/93

--- a/test/python/primitive_test.py
+++ b/test/python/primitive_test.py
@@ -10,6 +10,7 @@ from fixture.foo import (CultureAgnosticName, Dog,
                          FloatUnbox, Gender, ImportedTypeUnbox, Irum,
                          Line, MixedName, Mro, Music, NoMro, NullService,
                          Point1, Point2, Point3d, Pop, PingService, Product,
+                         RecordWithOptionalRecordField,
                          ReservedKeywordEnum, ReservedKeywordUnion,
                          Rnb, RpcError, Run, Status, Stop, Way, WesternName)
 from fixture.foo.bar import PathUnbox, IntUnbox, Point
@@ -150,6 +151,13 @@ def test_record():
     }
     assert point3d.__nirum_serialize__() == point3d_serialize
     assert Point3d.__nirum_deserialize__(point3d_serialize) == point3d
+
+    # Optional fields can be empty
+    r = RecordWithOptionalRecordField(f=None)
+    assert r.__nirum_serialize__() == {
+        '_type': 'record_with_optional_record_field',
+        'f': None,
+    }
 
 
 def test_record_with_one_field():


### PR DESCRIPTION
This fixes a bug that PR #201 introduced.

When a record or a union tag has an optional field, the generated Python serializers had been able to unexpectedly crash if the field contains `None`.

See also the added test case.