### PR TITLE
Fix the way to mangle temporary local variables used by serializers

### DIFF
--- a/test/nirum_fixture/fixture/foo.nrm
+++ b/test/nirum_fixture/fixture/foo.nrm
@@ -129,3 +129,7 @@ service sample-service (
     sample-method (animal a, product b/bb, gender c, way d/dd,
                    uuid e, binary f/ff, bigint g, text h/hh),
 );
+
+record record-with-map (
+    {text: text} text-to-text,
+);

--- a/test/python/primitive_test.py
+++ b/test/python/primitive_test.py
@@ -5,14 +5,16 @@ from pytest import raises
 from nirum.service import Service
 from six import PY3
 
-from fixture.foo import (CultureAgnosticName, Dog,
+from fixture.foo import (Album, CultureAgnosticName, Dog,
                          EastAsianName, EvaChar,
                          FloatUnbox, Gender, ImportedTypeUnbox, Irum,
                          Line, MixedName, Mro, Music, NoMro, NullService,
+                         Person, People,
                          Point1, Point2, Point3d, Pop, PingService, Product,
-                         RecordWithOptionalRecordField,
+                         RecordWithMap, RecordWithOptionalRecordField,
                          ReservedKeywordEnum, ReservedKeywordUnion,
-                         Rnb, RpcError, Run, Status, Stop, Way, WesternName)
+                         Rnb, RpcError, Run, Song, Status, Stop, Way,
+                         WesternName)
 from fixture.foo.bar import PathUnbox, IntUnbox, Point
 from fixture.qux import Path, Name
 
@@ -350,4 +352,44 @@ def test_nirum_tag_classes():
     assert Status.__nirum_tag_classes__ == {
         Status.Tag.run: Run,
         Status.Tag.stop: Stop,
+    }
+
+
+def test_list_serializer():
+    album = Album(name=u'Album title', tracks=[Song(name=u'Song title')])
+    assert album.__nirum_serialize__() == {
+        '_type': 'album',
+        'name': u'Album title',
+        'tracks': [
+            {'_type': 'song', 'name': u'Song title'},
+        ],
+    }
+
+
+def test_set_serializer():
+    people = People(people={
+        Person(first_name=Name(u'First'), last_name=Name(u'Last')),
+    })
+    assert people.__nirum_serialize__() == {
+        '_type': 'people',
+        'people': [
+            {
+                '_type': 'person',
+                'first_name': u'First',
+                'last_name': u'Last',
+            },
+        ]
+    }
+
+
+def test_map_serializer():
+    record = RecordWithMap(text_to_text={u'key': u'value'})
+    assert record.__nirum_serialize__() == {
+        '_type': 'record_with_map',
+        'text_to_text': [
+            {
+                'key': u'key',
+                'value': u'value',
+            },
+        ],
     }


### PR DESCRIPTION
Generated serializers had to generated temporary local variables and referred to it, but sometimes these had had an invalid name (e.g., `__self.field_name__elem__`).  This patch fixes the bug besides the following bugs:

  -  A bug that map types had been serialized in JSON to `{k: v}` while these should be `[{"key": k, "value": v}]`.

  -  A potential bug that temporary variables had been leaked to their outer scope in Python 2 since local variables in list comprehensions aren't isolated in Python 2.  See also [*What's New in Python 3.0*][1]:

        > Also note that list comprehensions have different semantics: they are closer to syntactic sugar for a generator expression inside a [`list()`][2] constructor, and in particular the loop control variables are no longer leaked into the surrounding scope.

[1]: https://docs.python.org/3/whatsnew/3.0.html#changed-syntax
[2]: https://docs.python.org/3/library/stdtypes.html#list