### PR TITLE
Optional parameters can be omitted

### DIFF
--- a/test/nirum_fixture/fixture/foo.nrm
+++ b/test/nirum_fixture/fixture/foo.nrm
@@ -128,6 +128,7 @@ union animal = cat
 service sample-service (
     sample-method (animal a, product b/bb, gender c, way d/dd,
                    uuid e, binary f/ff, bigint g, text h/hh),
+    optional-parameter-method (bigint r, bigint? o),
 );
 
 record record-with-map (

--- a/test/python/service_test.py
+++ b/test/python/service_test.py
@@ -1,6 +1,7 @@
 import uuid
 
 from nirum.transport import Transport
+from pytest import raises
 
 from fixture.foo import (Dog, Gender, PingService, Product, RpcError,
                          SampleService_Client, Way)
@@ -83,3 +84,14 @@ def test_service_client_payload_serialization():
         'g': 1234,
         'hh': 'text data',
     }
+
+
+def test_service_client_optional_parameter():
+    t = DumbTransport()
+    c = SampleService_Client(t)
+    c.optional_parameter_method(r=1, o=1)
+    c.optional_parameter_method(r=1)
+    with raises(TypeError):
+        c.optional_parameter_method(o=1)
+    with raises(TypeError):
+        c.optional_parameter_method()


### PR DESCRIPTION
Make optional parameters to be omitted. it refers to implementation of record intializer not to allow positional argument in Python 2.  
  