### PR TITLE
Avoid typing.Type[T] for compatibility with Python < 3.5.2

### DIFF
--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -750,12 +750,7 @@ class #{className}(object):
     __nirum_type__ = 'unboxed'
 
     @staticmethod
-%{ case pyVer }
-%{ of Python2 }
     def __nirum_get_inner_type__():
-%{ of Python3 }
-    def __nirum_get_inner_type__() -> typing.Type['#{itypeExpr}']:
-%{ endcase }
         return #{itypeExpr}
 
 %{ case pyVer }


### PR DESCRIPTION
It's a bugfix of regression made by my previous PR #211.  As `typinng.Type[T]` has been available since Python 3.5.2, the previous versions raise `AttributeError`.  Unfortunately, we currently cannot use that generic abstract type.