### PR TITLE
Automatically rebuild macOS build (upto 5 times) if it's failed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,9 @@ before_deploy:
   fi
 notifications:
   webhooks:
-    urls: ['https://webhooks.gitter.im/e/29cc2477daa438db4e9d']
+    urls:
+    - https://webhooks.gitter.im/e/29cc2477daa438db4e9d
+    - 'http://travis-auto-rebuilder.herokuapp.com/76caecf7-abe1-4122-9fcc-aa5226dc10f8/?jobs=1&retries=5'
     on_success: change
     on_failure: always
     on_start: never


### PR DESCRIPTION
As our macOS build is quite fragile and it's due to Travis CI's own problem (e.g., the hard time limit of PR build jobs, an undersupply of macOS workers), we hardly could fix it properly (i.e., make its result deterministic).  So instead I made it to be automatically retried upto 5 times if it's failed.  Note that it doesn't affect to Linux build jobs.

See also <https://github.com/dahlia/travis-auto-rebuilder>.