### PR TITLE
Upgrade to Stackage LTS Haskell 10.3

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -26,9 +26,17 @@ extra-source-files:
 - README.md
 default-extensions:
 - OverloadedStrings
-ghc-options:
-- -Wall
-- -Werror
+when:
+- condition: os(darwin)
+  else:
+    ghc-options:
+    - -Wall
+    - -Werror
+  then:
+    ghc-options:
+    - -Wall
+    - -Werror
+    - -optP-Wno-nonportable-include-path
 dependencies:
 - base >=4.7 && <5
 - blaze-html >=0.9.0.1 && <0.10
@@ -39,7 +47,7 @@ dependencies:
 - filepath >=1.4 && <1.5
 - htoml >=1.0.0.0 && <1.1.0.0
 - interpolatedstring-perl6 >=1.0.0 && <1.1.0
-- megaparsec >=5 && <5.4
+- megaparsec >=6.3 && <6.4
 - mtl >=2.2.1 && <3
 - parsec  # only for dealing with htoml's ParserError
 - pretty >=1.1.3 && <2
@@ -58,7 +66,7 @@ library:
   - cmark >=0.5 && <0.6
   - fsnotify >=0.2.1 && <0.3.0
   - heterocephalus >=1.0.5 && <1.1.0
-  - optparse-applicative >=0.13.1 && <0.14
+  - optparse-applicative >=0.14 && <0.15
   - shakespeare >=2.0.12 && <2.1
   - stm >=2.4.4.1
   - template-haskell >=2.11 && <3

--- a/src/Nirum/Cli.hs
+++ b/src/Nirum/Cli.hs
@@ -18,11 +18,7 @@ import System.Exit (die)
 import System.FilePath (takeDirectory, takeExtension, (</>))
 import System.FSNotify
 import Text.InterpolatedString.Perl6 (qq)
-import Text.Megaparsec (Token)
-import Text.Megaparsec.Error ( Dec
-                             , ParseError (errorPos)
-                             , parseErrorPretty
-                             )
+import Text.Megaparsec.Error (errorPos, parseErrorPretty)
 import Text.Megaparsec.Pos (SourcePos (sourceLine, sourceColumn), unPos)
 
 import Nirum.Constructs (Construct (toCode))
@@ -33,6 +29,7 @@ import Nirum.Package ( PackageError ( ImportError
                                     , ParseError
                                     , ScanError
                                     )
+                     , ParseError
                      , scanModules
                      )
 import Nirum.Package.ModuleSet ( ImportError ( CircularImportError
@@ -67,9 +64,7 @@ data AppOptions = AppOptions { outputPath :: FilePath
 debounceDelay :: Nanosecond
 debounceDelay = 1 * 1000 * 1000
 
-parseErrortoPrettyMessage :: ParseError (Token T.Text) Dec
-                          -> FilePath
-                          -> IO String
+parseErrortoPrettyMessage :: ParseError -> FilePath -> IO String
 parseErrortoPrettyMessage parseError' filePath' = do
     sourceCode <- readFile filePath'
     let sourceLines = lines sourceCode

--- a/src/Nirum/Constructs/Identifier.hs
+++ b/src/Nirum/Constructs/Identifier.hs
@@ -22,12 +22,12 @@ module Nirum.Constructs.Identifier ( Identifier
 import Data.Char (toLower, toUpper)
 import Data.Maybe (fromMaybe)
 import Data.String (IsString (fromString))
+import Data.Void
 
 import qualified Data.Text as T
 import qualified Data.Set as S
 import qualified Text.Megaparsec as P
 import Text.Megaparsec.Char (oneOf, satisfy)
-import Text.Megaparsec.Text (Parser)
 
 import Nirum.Constructs (Construct (toCode))
 
@@ -63,7 +63,7 @@ reservedKeywords = [ "enum"
                    , "union"
                    ]
 
-identifierRule :: Parser Identifier
+identifierRule :: P.Parsec Void T.Text Identifier
 identifierRule = do
     firstChar <- satisfy isAlpha
     restChars <- P.many $ satisfy isAlnum
@@ -88,7 +88,7 @@ fromText text =
         Right ident -> Just ident
         Left _ -> Nothing
   where
-    rule :: Parser Identifier
+    rule :: P.Parsec Void T.Text Identifier
     rule = do
         identifier' <- identifierRule
         _ <- P.eof

--- a/src/Nirum/Package.hs
+++ b/src/Nirum/Package.hs
@@ -1,6 +1,7 @@
 module Nirum.Package
     ( Package (..)
     , PackageError (..)
+    , ParseError
     , docs
     , resolveModule
     , scanModules

--- a/src/Nirum/Parser.hs
+++ b/src/Nirum/Parser.hs
@@ -32,6 +32,7 @@ module Nirum.Parser ( Parser
                     ) where
 
 import Control.Monad (void)
+import Data.Void
 import qualified System.IO as SIO
 
 import Data.Map.Strict as Map hiding (foldl)
@@ -47,8 +48,7 @@ import Text.Megaparsec.Char ( char
                             , string'
                             )
 import qualified Text.Megaparsec.Error as E
-import Text.Megaparsec.Text (Parser)
-import Text.Megaparsec.Lexer (charLiteral)
+import Text.Megaparsec.Char.Lexer (charLiteral)
 
 import qualified Nirum.Constructs.Annotation as A
 import Nirum.Constructs.Declaration (Declaration)
@@ -90,7 +90,8 @@ import Nirum.Constructs.TypeExpression ( TypeExpression ( ListModifier
                                                         )
                                        )
 
-type ParseError = E.ParseError (Token T.Text) E.Dec
+type Parser = Parsec Void T.Text
+type ParseError = E.ParseError Char Void
 
 comment :: Parser ()
 comment = string "//" >> void (many $ noneOf ("\n" :: String)) <?> "comment"
@@ -480,7 +481,7 @@ typeDeclaration = do
     let annotations = A.union annotationSet' $ typeAnnotations typeDecl
     return $ typeDecl { typeAnnotations = annotations }
   where
-    unless' :: [String] -> Parser a -> Parser a
+    unless' :: [T.Text] -> Parser a -> Parser a
     unless' [] _ = fail "no candidates"  -- Must never happen
     unless' [s] p = notFollowedBy (string s) >> p
     unless' (x : xs) p = notFollowedBy (string x) >> unless' xs p

--- a/src/Nirum/Targets.hs
+++ b/src/Nirum/Targets.hs
@@ -1,14 +1,7 @@
 {-# LANGUAGE QuasiQuotes, ScopedTypeVariables, TemplateHaskell #-}
 module Nirum.Targets ( BuildError (CompileError, PackageError, TargetNameError)
                      , BuildResult
-                     , Target ( CompileError
-                              , CompileResult
-                              , compilePackage
-                              , parseTarget
-                              , showCompileError
-                              , targetName
-                              , toByteString
-                              )
+                     , Target (..)
                      , TargetName
                      , buildPackage
                      , targetNames

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,6 +4,7 @@ packages:
 - '.'
 extra-deps:
 - uri-0.1.6.4
+- Win32-2.6.2.0
 extra-package-dbs: []
 ghc-options:
   "$locals": -fhide-source-paths

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,10 @@
-resolver: lts-9.10
+resolver: lts-10.3
 flags: {}
 packages:
 - '.'
 extra-deps:
 - uri-0.1.6.4
 extra-package-dbs: []
+ghc-options:
+  "$locals": -fhide-source-paths
+require-stack-version: ">=1.6.3"


### PR DESCRIPTION
Ignore the below explanation — I finally succeeded to make it to build well on macOS by passing `-optP-Wno-nonportable-include-path` to `ghc-options`.

~This PR cannot be merged at this time.~

~It's currently failed to build on macOS due to a Cabal's bug: haskell/cabal#4739.  We need to wait until:~

1. ~haskell/cabal#4739 is fixed, and~
2. ~the fix is released, and lastly~
3. ~it's included by an LTS release of Stackage~

~which means we will rename the version number in the title of this PR and the commit message.~