### PR TITLE
Rebuild macOS job only if Linux job is passed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ notifications:
   webhooks:
     urls:
     - https://webhooks.gitter.im/e/29cc2477daa438db4e9d
-    - 'http://travis-auto-rebuilder.herokuapp.com/76caecf7-abe1-4122-9fcc-aa5226dc10f8/?jobs=1&retries=5'
+    - 'http://travis-auto-rebuilder.herokuapp.com/76caecf7-abe1-4122-9fcc-aa5226dc10f8/?jobs=1&subject-to=2&retries=5'
     on_success: change
     on_failure: always
     on_start: never


### PR DESCRIPTION
The previous auto rebuilder parameter (see also #213) tries to retry broken macOS builds regardless whether the Linux job next to them is passed or not.  If a Linux job is not passed either macOS job shouldn't be retried and whole build should be properly fixed instead.  This change the auto rebuilder is triggered subject to the result of a Linux job.