### PR TITLE
Collapse error messages

### DIFF
--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -792,12 +792,7 @@ class #{className}(object):
 %{ of Python3 }
     def __nirum_deserialize__(cls: type, value: typing.Any) -> '#{className}':
 %{ endcase }
-        try:
-            inner_type = cls.__nirum_get_inner_type__()
-        except AttributeError:
-            # FIXME: __nirum_inner_type__ is for backward compatibility;
-            #        remove __nirum_inner_type__ in the near future.
-            inner_type = cls.__nirum_inner_type__
+        inner_type = cls.__nirum_get_inner_type__()
         deserializer = getattr(inner_type, '__nirum_deserialize__', None)
         if deserializer:
             value = deserializer(value)
@@ -1078,23 +1073,26 @@ class $className({T.intercalate "," $ compileExtendClasses annotations}):
                     break
             else:
                 raise ValueError(
-                    '%r is not deserialzable tag of `%s`.' % (
+                    '%r is not deserialzable tag of `%s`' % (
                         value, typing._type_repr(cls)
                     )
                 )
         if not cls.__nirum_union_behind_name__ == value['_type']:
-            raise ValueError('%s expect "_type" equal to'
-                             ' "%s"'
-                             ', but found %s.' % (
-                                typing._type_repr(cls),
-                                cls.__nirum_union_behind_name__,
-                                value['_type']))
+            raise ValueError(
+                '%s expect "_type" equal to "%s", but found %s' % (
+                    typing._type_repr(cls),
+                    cls.__nirum_union_behind_name__,
+                    value['_type']
+                )
+            )
         if not cls.__nirum_tag__.value == value['_tag']:
-            raise ValueError('%s expect "_tag" equal to'
-                             ' "%s"'
-                             ', but found %s.' % (typing._type_repr(cls),
-                                                  cls.__nirum_tag__.value,
-                                                  cls))
+            raise ValueError(
+                '%s expect "_tag" equal to "%s", but found %s' % (
+                    typing._type_repr(cls),
+                    cls.__nirum_tag__.value,
+                    cls
+                )
+            )
         args = dict()
         behind_names = cls.__nirum_tag_names__.behind_names
         errors = set()

--- a/test/python/primitive_test.py
+++ b/test/python/primitive_test.py
@@ -110,6 +110,14 @@ def test_record():
         Point1.__nirum_deserialize__({'x': 3, 'top': 14})
     with raises(ValueError):
         Point1.__nirum_deserialize__({'_type': 'foo'})
+    with raises(ValueError) as e:
+        Point1.__nirum_deserialize__({'_type': 'point1',
+                                      'left': 'a',
+                                      'top': 'b'})
+    assert str(e.value) == '''\
+left: invalid literal for int() with base 10: 'a'
+top: invalid literal for int() with base 10: 'b'\
+'''
     with raises(TypeError):
         Point1(left=1, top='a')
     with raises(TypeError):

--- a/test/python/primitive_test.py
+++ b/test/python/primitive_test.py
@@ -258,6 +258,24 @@ def test_union():
     assert agnostic_name != CultureAgnosticName(fullname=u'wrong')
     with raises(TypeError):
         CultureAgnosticName(fullname=1)
+    name = MixedName.__nirum_deserialize__({
+        '_type': 'mixed_name',
+        '_tag': 'east_asian_name',
+        'family_name': u'foo',
+        'given_name': u'bar',
+    })
+    assert isinstance(name, MixedName.EastAsianName)
+    with raises(ValueError) as e:
+        MixedName.__nirum_deserialize__({
+            '_type': 'mixed_name',
+            '_tag': 'east_asian_name',
+            'family_name': 404,
+            'given_name': 503,
+        })
+    assert str(e.value) == '''\
+family_name: '404' is not a string.
+given_name: '503' is not a string.\
+'''
 
 
 def test_union_with_special_case():


### PR DESCRIPTION
 In this patch, `ValueError` of deserialization shows all error messages at a time. (closes #168)

```
ValueError: family_name: '404' is not a string.
given_name: '503' is not a string.
```