### PR TITLE
Make record/union deserializers ignore unknown fields

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,13 @@ Version 0.3.1
 
 To be released.
 
+### Python target
+
+ -  Fixed record/union deserializers to ignore unknown fields in data payload.
+    Deserializers had raised `KeyError` before.  [#232]
+
+[#232]: https://github.com/spoqa/nirum/issues/232
+
 
 Version 0.3.0
 -------------
@@ -172,7 +179,6 @@ Released on February 18, 2018.
 [#203]: https://github.com/spoqa/nirum/pull/203
 [#204]: https://github.com/spoqa/nirum/pull/204
 [#216]: https://github.com/spoqa/nirum/issues/216
-[#222]: https://github.com/spoqa/nirum/pull/222
 [#218]: https://github.com/spoqa/nirum/issues/218
 [#222]: https://github.com/spoqa/nirum/pull/222
 [#223]: https://github.com/spoqa/nirum/pull/223

--- a/docs/refactoring.md
+++ b/docs/refactoring.md
@@ -129,6 +129,15 @@ returns, but in program codes we become able to deal with distance using `meter`
 type rather than primitive `bigint` type.
 
 
+Removing a field
+----------------
+
+Any fields in payload that are unlisted in an interface definition are ignored
+by a deserializer.  If you are going to remove an existing field you should
+deploy the newer version to a payload consumer first, and then a payload
+provider last.
+
+
 Interchangeability of enum type and `text`
 ------------------------------------------
 

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -201,6 +201,10 @@ It's represented in JSON to:
         "uri": null
     }
 
+When a payload is deserialized, undefined fields are just ignored.
+It can be used to drop an existing field without breaking
+backward compatibility.
+
 
 Union type
 ----------
@@ -242,6 +246,9 @@ It's represented in JSON to:
         "gender": "male",
         "uri": null
     }
+
+In a similar way to a recrod type, undefined fields in a payload are ignored
+by deserializer.
 
 
 Option type

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -966,7 +966,11 @@ class $className(object):
             else:
                 name = attribute_name
             try:
-                args[name] = deserialize_meta(field_types[name], item)
+                field_type = field_types[name]
+            except KeyError:
+                continue
+            try:
+                args[name] = deserialize_meta(field_type, item)
             except ValueError as e:
                 errors.add('%s: %s' % (attribute_name, str(e)))
         if errors:
@@ -1107,7 +1111,11 @@ class $className({T.intercalate "," $ compileExtendClasses annotations}):
                 name = attribute_name
             tag_types = dict(cls.__nirum_tag_types__())
             try:
-                args[name] = deserialize_meta(tag_types[name], item)
+                field_type = tag_types[name]
+            except KeyError:
+                continue
+            try:
+                args[name] = deserialize_meta(field_type, item)
             except ValueError as e:
                 errors.add('%s: %s' % (attribute_name, str(e)))
         if errors:


### PR DESCRIPTION
Fixes #232.  See also *docs/refactoring.md* and *CHANGES.md*.