### PR TITLE
Serialization test suite

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,8 +11,21 @@ To be released.
  -  Union tags became possible to have `default` keyword.  It's useful
     for migrating a record type to a union type.  [[#13], [#227]]
 
+### Python target
+
+ -  Generated Python packages became to have two [entry points] (a feature
+    provided by *setuptools*):
+     -  `nirum.modules`: It maps Nirum modules to Python modules.
+        Nirum module paths are normalized to avoid underscores and upper letters
+        and use hyphens and lower letters instead, e.g., `foo-bar.baz`.
+        The table works well with `renames` settings as well.
+     -  `nirum.classes`: It maps Nirum types (including services) to Python
+        classes.  Nirum type names are qualified and their leading module paths
+        are also normalized (the same rule to `nirum.modules` applies here).
+
 [#13]: https://github.com/spoqa/nirum/issues/13
 [#227]: https://github.com/spoqa/nirum/pull/227
+[entry points]: https://setuptools.readthedocs.io/en/latest/pkg_resources.html#entry-points
 
 
 Version 0.3.1

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -702,7 +702,7 @@ compilePrimitiveTypeSerializer Binary var =
 compilePrimitiveTypeSerializer Date var = [qq|($var).isoformat()|]
 compilePrimitiveTypeSerializer Datetime var = [qq|($var).isoformat()|]
 compilePrimitiveTypeSerializer Bool var = var
-compilePrimitiveTypeSerializer Uuid var = [qq|str($var)|]
+compilePrimitiveTypeSerializer Uuid var = [qq|str($var).lower()|]
 compilePrimitiveTypeSerializer Uri var = var
 
 compileTypeDeclaration :: Source -> TypeDeclaration -> CodeGen Code

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -74,6 +74,7 @@ import qualified Nirum.Constructs.Annotation as A
 import qualified Nirum.Constructs.DeclarationSet as DS
 import qualified Nirum.Constructs.Identifier as I
 import Nirum.Constructs.Declaration (Documented (docsBlock))
+import Nirum.Constructs.Module hiding (imports)
 import Nirum.Constructs.ModulePath ( ModulePath
                                    , fromIdentifiers
                                    , hierarchy
@@ -1122,7 +1123,7 @@ class #{className}(#{T.intercalate "," $ compileExtendClasses annotations}):
     #{className}.Tag.#{toEnumMemberName tn}: #{toClassName' tn},
 %{ endforall }
 })
-            |]
+|]
   where
     tags' :: [Tag]
     tags' = DS.toList $ tags union
@@ -1544,9 +1545,34 @@ setup(
     setup_requires=setup_requires,
     install_requires=install_requires,
     extras_require=extras_require,
+    entry_points={
+        'nirum.modules': [
+%{ forall modPath <- MS.keys modules' }
+            '#{normalizeModulePath modPath} = #{toImportPath target' modPath}',
+%{ endforall }
+        ],
+        'nirum.classes': [
+%{ forall (modPath, Module types' _) <- MS.toList modules' }
+%{ forall typeName <- catMaybes (typeNames types') }
+            '#{normalizeModulePath modPath}.#{I.toNormalizedText typeName} = '
+            '#{toImportPath target' modPath}:#{toClassName typeName}',
+%{ endforall }
+%{ endforall }
+        ],
+    },
 )
 |]
   where
+    normalizeModulePath :: ModulePath -> T.Text
+    normalizeModulePath = T.intercalate "." . map I.toNormalizedText . toList
+    typeNames :: DS.DeclarationSet TD.TypeDeclaration -> [Maybe I.Identifier]
+    typeNames types' =
+        [ case td of
+              TD.TypeDeclaration { TD.typename = (Name n _) } -> Just n
+              TD.ServiceDeclaration { TD.serviceName = (Name n _) } -> Just n
+              TD.Import {} -> Nothing
+        | td <- DS.toList types'
+        ]
     nStringLiteral :: Maybe T.Text -> T.Text
     nStringLiteral (Just value) = stringLiteral value
     nStringLiteral Nothing = "None"

--- a/test/nirum_fixture/fixture/types.nrm
+++ b/test/nirum_fixture/fixture/types.nrm
@@ -1,0 +1,1 @@
+record uuid-list ([uuid] values);

--- a/test/python/serialization_test.py
+++ b/test/python/serialization_test.py
@@ -1,0 +1,66 @@
+from __future__ import print_function
+
+import functools
+import io
+import json
+import os
+import os.path
+import pkg_resources
+import pprint
+from typing import _type_repr
+
+from pytest import mark
+
+
+test_suite_dir = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), '..', 'serialization')
+)
+
+
+def list_specs(path):
+    for f in os.listdir(path):
+        filename = os.path.join(path, f)
+        if os.path.isdir(filename):
+            for subf in list_specs(filename):
+                yield subf
+        elif f.lower().endswith('.json'):
+            yield filename
+
+
+dump_json = functools.partial(
+    json.dumps,
+    indent=2,
+    ensure_ascii=False,
+    sort_keys=True
+)
+
+
+@mark.parametrize('spec_file', list_specs(test_suite_dir))
+def test_serializer_deserializer(spec_file):
+    with io.open(spec_file, 'r', encoding='utf-8') as f:
+        spec = json.load(f)
+    print()
+    print('Spec:', os.path.relpath(spec_file, test_suite_dir))
+    print('Description:', spec['description'])
+    print('Type:', spec['type'])
+    candidates = list(
+        pkg_resources.iter_entry_points('nirum.classes', name=spec['type'])
+    )
+    assert candidates, (
+        'Failed to resolve a corresponding Python class to the Nirum '
+        'type "{0}".'.format(spec['type'])
+    )
+    assert len(candidates) < 2, (
+        'Too many classes are mapped to the Nirum type name "{0}":\n'
+        '{1}'.format(spec['type'], '\n'.join(map(str, candidates)))
+    )
+    cls = candidates[0].resolve()
+    print('Class:', _type_repr(cls))
+    print('Input:', dump_json(spec['input']))
+    deserialized = cls.__nirum_deserialize__(spec['input'])
+    print('Deserialized:', pprint.pformat(deserialized))
+    print('Normal:', dump_json(spec['normal']))
+    serialized = deserialized.__nirum_serialize__()
+    print('Serialized:', dump_json(serialized))
+    assert serialized == spec['normal']
+    print()

--- a/test/python/setup_test.py
+++ b/test/python/setup_test.py
@@ -1,5 +1,8 @@
 import pkg_resources
 
+from fixture.foo import FloatUnbox, Irum
+from renamed.foo import FooTest
+
 
 def parse_pkg_info(pkg_name):
     d = pkg_resources.get_distribution(pkg_name)
@@ -18,8 +21,31 @@ def test_setup_metadata():
     assert ['nirum'] == pkg['Requires']
     assert set(pkg['Provides']) == {
         'fixture', 'fixture.foo', 'fixture.foo.bar', 'fixture.qux',
+        'fixture.types',
         'renamed', 'renamed.foo', 'renamed.foo.bar',
     }
     assert ['0.3.0'] == pkg['Version']
     assert ['Package description'] == pkg['Summary']
     assert ['MIT'] == pkg['License']
+
+
+def test_module_entry_points():
+    map_ = pkg_resources.get_entry_map('nirum_fixture', group='nirum.modules')
+    assert frozenset(map_) == {
+        'fixture.foo', 'fixture.foo.bar', 'fixture.qux',
+        'fixture.types',
+        'renames.test.foo', 'renames.test.foo.bar',
+    }
+    import fixture.foo
+    assert map_['fixture.foo'].resolve() is fixture.foo
+    import fixture.foo.bar
+    assert map_['fixture.foo.bar'].resolve() is fixture.foo.bar
+    import renamed.foo
+    assert map_['renames.test.foo'].resolve() is renamed.foo
+
+
+def test_class_entry_points():
+    map_ = pkg_resources.get_entry_map('nirum_fixture', group='nirum.classes')
+    assert map_['fixture.foo.float-unbox'].resolve() is FloatUnbox
+    assert map_['fixture.foo.irum'].resolve() is Irum
+    assert map_['renames.test.foo.foo-test'].resolve() is FooTest

--- a/test/serialization/.check
+++ b/test/serialization/.check
@@ -1,0 +1,3 @@
+- If any serialization rule is added or changed it should be also updated to
+  docs as well.  See also *docs/serialization.md*, *docs/refactoring.md*,
+  and so on.

--- a/test/serialization/primitive-types/uuid.json
+++ b/test/serialization/primitive-types/uuid.json
@@ -1,0 +1,22 @@
+{
+    "description": "Although UUID strings can have various forms, its normalization form is lowercase hex digits in standard form (e.g., 118fe23b-0380-4d15-8f2d-9f8c6f55e5a5).",
+    "type": "fixture.types.uuid-list",
+    "input": {
+        "_type": "uuid_list",
+        "values": [
+            "118fe23b-0380-4d15-8f2d-9f8c6f55e5a5",
+            "118FE23B-0380-4D15-8F2D-9F8C6F55E5A5",
+            "118fe23b03804d158f2d-9f8c6f55e5a5",
+            "118FE23B03804D158F2D9F8C6F55E5A5"
+        ]
+    },
+    "normal": {
+        "_type": "uuid_list",
+        "values": [
+            "118fe23b-0380-4d15-8f2d-9f8c6f55e5a5",
+            "118fe23b-0380-4d15-8f2d-9f8c6f55e5a5",
+            "118fe23b-0380-4d15-8f2d-9f8c6f55e5a5",
+            "118fe23b-0380-4d15-8f2d-9f8c6f55e5a5"
+        ]
+    }
+}

--- a/test/serialization/records/unknown-fields.json
+++ b/test/serialization/records/unknown-fields.json
@@ -1,0 +1,15 @@
+{
+    "description": "Unknown fields should be ignored.",
+    "type": "fixture.foo.person",
+    "input": {
+        "_type": "person",
+        "first_name": "John",
+        "last_name": "Doe",
+        "full_name": "John Doe (unknown field)"
+    },
+    "normal": {
+        "_type": "person",
+        "first_name": "John",
+        "last_name": "Doe"
+    }
+}

--- a/test/serialization/sets/duplicate-elements.json
+++ b/test/serialization/sets/duplicate-elements.json
@@ -1,0 +1,29 @@
+{
+    "description": "If a set contains duplicate values they should be ignored except for any one.",
+    "type": "fixture.foo.people",
+    "input": {
+        "_type": "people",
+        "people": [
+            {
+                "_type": "person",
+                "first_name": "John",
+                "last_name": "Doe"
+            },
+            {
+                "_type": "person",
+                "first_name": "John",
+                "last_name": "Doe"
+            }
+        ]
+    },
+    "normal": {
+        "_type": "people",
+        "people": [
+            {
+                "_type": "person",
+                "first_name": "John",
+                "last_name": "Doe"
+            }
+        ]
+    }
+}

--- a/test/serialization/unions/default-tag.json
+++ b/test/serialization/unions/default-tag.json
@@ -1,0 +1,13 @@
+{
+    "description": "If a value of union type lacks \"_tag\" field, it should be treated as a default tag.",
+    "type": "fixture.foo.mixed-name",
+    "input": {
+        "_type": "mixed_name",
+        "fullname": "John Doe"
+    },
+    "normal": {
+        "_type": "mixed_name",
+        "_tag": "culture_agnostic_name",
+        "fullname": "John Doe"
+    }
+}

--- a/test/serialization/unions/unknown-fields.json
+++ b/test/serialization/unions/unknown-fields.json
@@ -1,0 +1,16 @@
+{
+    "description": "Unknown fields should be ignored.",
+    "type": "fixture.foo.mixed-name",
+    "input": {
+        "_type": "mixed_name",
+        "_tag": "culture_agnostic_name",
+        "fullname": "John Doe",
+        "first": "John (unknown field)",
+        "last": "Doe (unknown field)"
+    },
+    "normal": {
+        "_type": "mixed_name",
+        "_tag": "culture_agnostic_name",
+        "fullname": "John Doe"
+    }
+}

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
 commands =
     pip install -f {distdir} -e {distdir}/nirum_fixture
     flake8 test/python
-    pytest {posargs:--ff -vv -s} test/python
+    pytest {posargs:--ff -vv} test/python
 
 [testenv:buildfixture]
 skip_install = true


### PR DESCRIPTION
This PR adds the basic test suite for serialization/deserialization rules suggested by #239.  The format of spec files is quite different from what #239 suggested.  Here's key differences:

 -  To make these easier to organize, I intended “one file for one spec” rather than pairing two JSON files for a spec which #239 suggested.
 -  I intentionally chose a term *normal* instead of *expected* to make it clear that it's about what is the normal form.
 -  During implementing this, I figured out that we need a way to resolve a Nirum type what a spec tests about; Not only `"_type"` field is not enough, it even is not there for some cases (unboxed types based on primitive types, enum types, lists, maps, sets, et cetera; there are a lot more).  So I introduced a distinct `"type"` field for a spec and it uses entry points to resolve a Python class corresponding to a Nirum type.

What's [entry points]?  It's Python's de facto standard for discovering things among installed independent packages through consensus.  You could find examples from [Jinja implementing Babel's extractors][1] (through [`babel.extractors` entry points group][2]).

In a similar way, we now have two entry points groups: `nirum.modules` and `nirum.classes`.  Quoted from the changelog for this:

> -  `nirum.modules`: It maps Nirum modules to Python modules. Nirum module paths are normalized to avoid underscores and upper letters and use hyphens and lower letters instead, e.g., `foo-bar.baz`. The table works well with `renames` settings as well.
> -  `nirum.classes`: It maps Nirum types (including services) to Python classes.  Nirum type names are qualified and their leading module paths are also normalized (the same rule to `nirum.modules` applies here).

[entry points]: https://setuptools.readthedocs.io/en/latest/pkg_resources.html#entry-points
[1]: http://jinja.pocoo.org/docs/2.10/integration/#babel-integration
[2]: http://babel.pocoo.org/en/latest/messages.html#writing-extraction-methods