### PR TITLE
Divide Python target into submodules

### DIFF
--- a/src/Nirum/Targets/Python.hs-boot
+++ b/src/Nirum/Targets/Python.hs-boot
@@ -1,0 +1,7 @@
+{-# OPTIONS_GHC -Wno-missing-methods -Wno-orphans #-}
+module Nirum.Targets.Python () where
+
+import Nirum.Package.Metadata (Target (..))
+import Nirum.Targets.Python.CodeGen as CG
+
+instance Target Python where

--- a/src/Nirum/Targets/Python/CodeGen.hs
+++ b/src/Nirum/Targets/Python/CodeGen.hs
@@ -1,0 +1,208 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+module Nirum.Targets.Python.CodeGen
+    ( Code
+    , CodeGen
+    , CodeGenContext (..)
+    , CompileError
+    , Python (..)
+    , PythonVersion (..)
+    , RenameMap
+    , empty
+    , getPythonVersion
+    , insertLocalImport
+    , insertStandardImport
+    , insertThirdPartyImports
+    , insertThirdPartyImportsA
+    , importTypingForPython3
+    , keywords
+    , localImportsMap
+    , mangleVar
+    , minimumRuntime
+    , renameModulePath
+    , renameModulePath'
+    , runCodeGen
+    , toAttributeName
+    , toAttributeName'
+    , toClassName
+    , toClassName'
+    , toImportPath'
+    , toImportPath
+    , toImportPaths
+    ) where
+
+import Control.Monad.State
+import Data.Typeable
+import GHC.Exts
+
+import Data.Map.Strict hiding (empty, member, toAscList)
+import Data.SemVer hiding (Identifier)
+import Data.Set hiding (empty)
+import Data.Text hiding (empty)
+
+import qualified Nirum.CodeGen
+import Nirum.Constructs.Identifier
+import Nirum.Constructs.ModulePath
+import Nirum.Constructs.Name
+
+minimumRuntime :: Version
+minimumRuntime = version 0 6 0 [] []
+
+-- | The set of Python reserved keywords.
+-- See also: https://docs.python.org/3/reference/lexical_analysis.html#keywords
+keywords :: Set Code
+keywords = [ "False", "None", "True"
+           , "and", "as", "assert", "break", "class", "continue"
+           , "def", "del" , "elif", "else", "except", "finally"
+           , "for", "from", "global", "if", "import", "in", "is"
+           , "lambda", "nonlocal", "not", "or", "pass", "raise"
+           , "return", "try", "while", "with", "yield"
+           ]
+
+type RenameMap = Map ModulePath ModulePath
+
+data Python = Python { packageName :: Text
+                     , minimumRuntimeVersion :: Version
+                     , renames :: RenameMap
+                     } deriving (Eq, Ord, Show, Typeable)
+
+data PythonVersion = Python2
+                   | Python3
+                   deriving (Eq, Ord, Show)
+
+type CompileError = Text
+type Code = Text
+
+data CodeGenContext
+    = CodeGenContext { standardImports :: Set Text
+                     , thirdPartyImports :: Map Text (Map Text Text)
+                     , localImports :: Map Text (Set Text)
+                     , pythonVersion :: PythonVersion
+                     }
+    deriving (Eq, Ord, Show)
+
+instance Nirum.CodeGen.Failure CodeGenContext CompileError where
+    fromString = return . pack
+
+empty :: PythonVersion -> CodeGenContext
+empty pythonVer = CodeGenContext
+    { standardImports = []
+    , thirdPartyImports = []
+    , localImports = []
+    , pythonVersion = pythonVer
+    }
+
+localImportsMap :: CodeGenContext -> Map Text (Map Text Text)
+localImportsMap CodeGenContext { localImports = imports } =
+    Data.Map.Strict.map (Data.Map.Strict.fromSet id) imports
+
+type CodeGen = Nirum.CodeGen.CodeGen CodeGenContext CompileError
+
+runCodeGen :: CodeGen a
+           -> CodeGenContext
+           -> (Either CompileError a, CodeGenContext)
+runCodeGen = Nirum.CodeGen.runCodeGen
+
+insertStandardImport :: Text -> CodeGen ()
+insertStandardImport module' = modify insert'
+  where
+    insert' c@CodeGenContext { standardImports = si } =
+        c { standardImports = Data.Set.insert module' si }
+
+insertThirdPartyImports :: [(Text, Set Text)] -> CodeGen ()
+insertThirdPartyImports imports =
+    insertThirdPartyImportsA [ (from, Data.Map.Strict.fromSet id objects)
+                             | (from, objects) <- imports
+                             ]
+
+insertThirdPartyImportsA :: [(Text, Map Text Text)] -> CodeGen ()
+insertThirdPartyImportsA imports =
+    modify insert'
+  where
+    insert' c@CodeGenContext { thirdPartyImports = ti } =
+        c { thirdPartyImports = Prelude.foldl (unionWith Data.Map.Strict.union)
+                                              ti
+                                              importList
+          }
+    importList :: [Map Text (Map Text Text)]
+    importList = [ Data.Map.Strict.singleton from objects
+                 | (from, objects) <- imports
+                 ]
+
+insertLocalImport :: Text -> Text -> CodeGen ()
+insertLocalImport module' object = modify insert'
+  where
+    insert' c@CodeGenContext { localImports = li } =
+        c { localImports = insertWith Data.Set.union module' [object] li }
+
+importTypingForPython3 :: CodeGen ()
+importTypingForPython3 = do
+    pyVer <- getPythonVersion
+    case pyVer of
+        Python2 -> return ()
+        Python3 -> insertStandardImport "typing"
+
+getPythonVersion :: CodeGen PythonVersion
+getPythonVersion = fmap pythonVersion Control.Monad.State.get
+
+renameModulePath :: RenameMap -> ModulePath -> ModulePath
+renameModulePath renameMap path' =
+    rename (Data.Map.Strict.toDescList renameMap)
+    -- longest paths should be processed first
+  where
+    rename :: [(ModulePath, ModulePath)] -> ModulePath
+    rename ((from, to) : xs) = let r = replacePrefix from to path'
+                               in if r == path'
+                                  then rename xs
+                                  else r
+    rename [] = path'
+
+renameModulePath' :: Python -> ModulePath -> ModulePath
+renameModulePath' Python { renames = table } = renameModulePath table
+
+toImportPath' :: ModulePath -> Text
+toImportPath' =
+    intercalate "." . fmap toAttributeName . GHC.Exts.toList
+
+toImportPath :: Python -> ModulePath -> Text
+toImportPath target' = toImportPath' . renameModulePath' target'
+
+toImportPaths :: Python -> Set ModulePath -> [Text]
+toImportPaths target' paths =
+    toAscList $ Data.Set.map toImportPath' $ hierarchies renamedPaths
+  where
+    renamedPaths :: Set ModulePath
+    renamedPaths = Data.Set.map (renameModulePath' target') paths
+
+toClassName :: Identifier -> Text
+toClassName identifier =
+    if className `member` keywords then className `snoc` '_' else className
+  where
+    className :: Text
+    className = toPascalCaseText identifier
+
+toClassName' :: Name -> Text
+toClassName' = toClassName . facialName
+
+toAttributeName :: Identifier -> Text
+toAttributeName identifier =
+    if attrName `member` keywords then attrName `snoc` '_' else attrName
+  where
+    attrName :: Text
+    attrName = toSnakeCaseText identifier
+
+toAttributeName' :: Name -> Text
+toAttributeName' = toAttributeName . facialName
+
+mangleVar :: Code -> Text -> Code
+mangleVar expr arbitrarySideName = Data.Text.concat
+    [ "__nirum_"
+    , (`Data.Text.map` expr) $ \ c ->
+          if 'A' <= c && c <= 'Z' || 'a' <= c && c <= 'z' || c == '_'
+          then c
+          else '_'
+    , "__"
+    , arbitrarySideName
+    , "__"
+    ]

--- a/src/Nirum/Targets/Python/TypeExpression.hs
+++ b/src/Nirum/Targets/Python/TypeExpression.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE QuasiQuotes #-}
+module Nirum.Targets.Python.TypeExpression
+    ( compileTypeExpression
+    , compilePrimitiveType
+    ) where
+
+import Data.Text
+import Text.InterpolatedString.Perl6 (qq)
+
+import Nirum.Constructs.Identifier
+import Nirum.Constructs.TypeDeclaration
+import Nirum.Constructs.TypeExpression
+import Nirum.Package.Metadata
+import {-# SOURCE #-} Nirum.Targets.Python ()
+import Nirum.Targets.Python.CodeGen
+import Nirum.TypeInstance.BoundModule
+
+compileTypeExpression :: BoundModule Python
+                      -> Maybe TypeExpression
+                      -> CodeGen Code
+compileTypeExpression mod' (Just (TypeIdentifier i)) =
+    case lookupType i mod' of
+        Missing -> fail $ "undefined identifier: " ++ toString i
+        Imported _ (PrimitiveType p _) -> compilePrimitiveType p
+        Imported m _ -> do
+            insertThirdPartyImports [(toImportPath target' m, [toClassName i])]
+            return $ toClassName i
+        Local _ -> return $ toClassName i
+  where
+    target' :: Python
+    target' = target $ metadata $ boundPackage mod'
+compileTypeExpression mod' (Just (MapModifier k v)) = do
+    kExpr <- compileTypeExpression mod' (Just k)
+    vExpr <- compileTypeExpression mod' (Just v)
+    insertStandardImport "typing"
+    return [qq|typing.Mapping[$kExpr, $vExpr]|]
+compileTypeExpression mod' (Just modifier) = do
+    expr <- compileTypeExpression mod' (Just typeExpr)
+    insertStandardImport "typing"
+    return [qq|typing.$className[$expr]|]
+  where
+    typeExpr :: TypeExpression
+    className :: Text
+    (typeExpr, className) = case modifier of
+        OptionModifier t' -> (t', "Optional")
+        SetModifier t' -> (t', "AbstractSet")
+        ListModifier t' -> (t', "Sequence")
+        TypeIdentifier _ -> undefined  -- never happen!
+        MapModifier _ _ -> undefined  -- never happen!
+compileTypeExpression _ Nothing =
+    return "None"
+
+compilePrimitiveType :: PrimitiveTypeIdentifier -> CodeGen Code
+compilePrimitiveType primitiveTypeIdentifier' = do
+    pyVer <- getPythonVersion
+    case (primitiveTypeIdentifier', pyVer) of
+        (Bool, _) -> return "bool"
+        (Bigint, _) -> return "int"
+        (Decimal, _) -> do
+            insertStandardImport "decimal"
+            return "decimal.Decimal"
+        (Int32, _) -> return "int"
+        (Int64, Python2) -> do
+            insertStandardImport "numbers"
+            return "numbers.Integral"
+        (Int64, Python3) -> return "int"
+        (Float32, _) -> return "float"
+        (Float64, _) -> return "float"
+        (Text, Python2) -> return "unicode"
+        (Text, Python3) -> return "str"
+        (Binary, _) -> return "bytes"
+        (Date, _) -> do
+            insertStandardImport "datetime"
+            return "datetime.date"
+        (Datetime, _) -> do
+            insertStandardImport "datetime"
+            return "datetime.datetime"
+        (Uuid, _) -> insertStandardImport "uuid" >> return "uuid.UUID"
+        (Uri, Python2) -> return "unicode"
+        (Uri, Python3) -> return "str"

--- a/test/Nirum/PackageSpec.hs
+++ b/test/Nirum/PackageSpec.hs
@@ -33,7 +33,8 @@ import Nirum.Package.ModuleSet ( ImportError (MissingModulePathError)
                                )
 import Nirum.Package.ModuleSetSpec (validModules)
 import Nirum.Parser (parseFile)
-import Nirum.Targets.Python (Python (Python), minimumRuntime)
+import Nirum.Targets.Python (Python (Python))
+import Nirum.Targets.Python.CodeGen (minimumRuntime)
 
 createPackage :: Metadata t -> [(ModulePath, Module)] -> Package t
 createPackage metadata' modules' =

--- a/test/Nirum/Targets/Python/CodeGenSpec.hs
+++ b/test/Nirum/Targets/Python/CodeGenSpec.hs
@@ -1,0 +1,201 @@
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE QuasiQuotes #-}
+module Nirum.Targets.Python.CodeGenSpec
+    ( makeDummySource
+    , makeDummySource'
+    , pythonVersionSpecs
+    , spec
+    ) where
+
+import Control.Monad
+import Data.Either
+import Data.Maybe
+
+import Data.SemVer hiding (Identifier, metadata)
+import Test.Hspec.Meta
+import Text.Email.Validate (emailAddress)
+import Text.InterpolatedString.Perl6 (qq)
+
+import Nirum.Constructs.Annotation (empty)
+import Nirum.Constructs.Identifier
+import Nirum.Constructs.Module
+import Nirum.Constructs.ModulePath
+import Nirum.Constructs.TypeDeclaration
+import Nirum.Package.Metadata
+import Nirum.Package.ModuleSet
+import Nirum.PackageSpec (createPackage)
+import Nirum.Targets.Python (Source (..))
+import Nirum.Targets.Python.CodeGen hiding (empty, renames)
+import qualified Nirum.Targets.Python.CodeGen as CodeGen
+import Nirum.TypeInstance.BoundModule
+
+makeDummySource' :: [Identifier] -> Module -> RenameMap -> Source
+makeDummySource' pathPrefix m renames =
+    Source pkg $ fromJust $ resolveBoundModule ["foo"] pkg
+  where
+    mp :: [Identifier] -> ModulePath
+    mp identifiers = fromJust $ fromIdentifiers (pathPrefix ++ identifiers)
+    metadata' :: Metadata Python
+    metadata' = Metadata
+        { Nirum.Package.Metadata.version = Data.SemVer.version 1 2 3 [] []
+        , authors =
+              [ Author
+                    { name = "John Doe"
+                    , email = Just (fromJust $ emailAddress "john@example.com")
+                    , uri = Nothing
+                    }
+              ]
+        , description = Just "Package description"
+        , license = Just "MIT"
+        , Nirum.Package.Metadata.keywords = ["sample", "example", "nirum"]
+        , target = Python "sample-package" minimumRuntime renames
+        }
+    pkg :: Package Python
+    pkg = createPackage
+            metadata'
+            [ (mp ["foo"], m)
+            , ( mp ["foo", "bar"]
+              , Module [ Import (mp ["qux"]) "path" empty
+                       , TypeDeclaration "path-unbox" (UnboxedType "path") empty
+                       , TypeDeclaration "int-unbox"
+                                         (UnboxedType "bigint") empty
+                       , TypeDeclaration "point"
+                                         (RecordType [ Field "x" "int64" empty
+                                                     , Field "y" "int64" empty
+                                                     ])
+                                         empty
+                       ] Nothing
+              )
+            , ( mp ["qux"]
+              , Module
+                  [ TypeDeclaration "path" (Alias "text") empty
+                  , TypeDeclaration "name" (UnboxedType "text") empty
+                  ]
+                  Nothing
+              )
+            ]
+
+makeDummySource :: Module -> Source
+makeDummySource m = makeDummySource' [] m []
+
+pythonVersionSpecs :: (PythonVersion -> Spec) -> Spec
+pythonVersionSpecs =
+    parallel . forM_ ([Python2, Python3] :: [PythonVersion])
+
+spec' :: Spec
+spec' = pythonVersionSpecs $ \ ver -> do
+    let empty' = CodeGen.empty ver
+        -- compileError :: CodeGen a -> Maybe CompileError
+        compileError cg = either Just (const Nothing) $ fst $
+            runCodeGen cg empty'
+
+    describe [qq|CodeGen ($ver)|] $ do
+        specify "packages and imports" $ do
+            let c = do
+                    insertStandardImport "sys"
+                    insertThirdPartyImports
+                        [("nirum", ["serialize_unboxed_type"])]
+                    insertLocalImport ".." "Gender"
+                    insertStandardImport "os"
+                    insertThirdPartyImports [("nirum", ["serialize_enum_type"])]
+                    insertThirdPartyImportsA
+                        [("nirum.constructs", [("name_dict_type", "NameDict")])]
+                    insertLocalImport ".." "Path"
+            let (e, ctx) = runCodeGen c empty'
+            e `shouldSatisfy` isRight
+            standardImports ctx `shouldBe` ["os", "sys"]
+            thirdPartyImports ctx `shouldBe`
+                [ ( "nirum"
+                  , [ ("serialize_unboxed_type", "serialize_unboxed_type")
+                    , ("serialize_enum_type", "serialize_enum_type")
+                    ]
+                  )
+                , ( "nirum.constructs"
+                  , [("name_dict_type", "NameDict")]
+                  )
+                ]
+            localImports ctx `shouldBe` [("..", ["Gender", "Path"])]
+            localImportsMap ctx `shouldBe`
+                [ ( ".."
+                  , [ ("Gender", "Gender")
+                    , ("Path", "Path")
+                    ]
+                  )
+                ]
+        specify "insertStandardImport" $ do
+            let codeGen1 = insertStandardImport "sys"
+            let (e1, ctx1) = runCodeGen codeGen1 empty'
+            e1 `shouldSatisfy` isRight
+            standardImports ctx1 `shouldBe` ["sys"]
+            thirdPartyImports ctx1 `shouldBe` []
+            localImports ctx1 `shouldBe` []
+            compileError codeGen1 `shouldBe` Nothing
+            let codeGen2 = codeGen1 >> insertStandardImport "os"
+            let (e2, ctx2) = runCodeGen codeGen2 empty'
+            e2 `shouldSatisfy` isRight
+            standardImports ctx2 `shouldBe` ["os", "sys"]
+            thirdPartyImports ctx2 `shouldBe` []
+            localImports ctx2 `shouldBe` []
+            compileError codeGen2 `shouldBe` Nothing
+
+spec :: Spec
+spec = do
+    spec'
+
+    describe "toClassName" $ do
+        it "transform the facial name of the argument into PascalCase" $ do
+            toClassName "test" `shouldBe` "Test"
+            toClassName "hello-world" `shouldBe` "HelloWorld"
+        it "appends an underscore to the result if it's a reserved keyword" $ do
+            toClassName "true" `shouldBe` "True_"
+            toClassName "false" `shouldBe` "False_"
+            toClassName "none" `shouldBe` "None_"
+
+    describe "toAttributeName" $ do
+        it "transform the facial name of the argument into snake_case" $ do
+            toAttributeName "test" `shouldBe` "test"
+            toAttributeName "hello-world" `shouldBe` "hello_world"
+        it "appends an underscore to the result if it's a reserved keyword" $ do
+            toAttributeName "def" `shouldBe` "def_"
+            toAttributeName "lambda" `shouldBe` "lambda_"
+            toAttributeName "nonlocal" `shouldBe` "nonlocal_"
+
+    specify "toImportPath" $ do
+        let (Source pkg _) = makeDummySource $ Module [] Nothing
+            target' = target $ metadata pkg
+        toImportPath target' ["foo", "bar"] `shouldBe` "foo.bar"
+
+    describe "toImportPaths" $ do
+        it "adds ancestors of packages" $ do
+            let (Source pkg _) = makeDummySource $ Module [] Nothing
+                modulePaths = keysSet $ modules pkg
+                target' = target $ metadata pkg
+            toImportPaths target' modulePaths `shouldBe`
+                [ "foo"
+                , "foo.bar"
+                , "qux"
+                ]
+        it "applies renames before add ancestors of packages" $ do
+            let (Source pkg _) = makeDummySource' [] (Module [] Nothing)
+                                                  [(["foo"], ["f", "oo"])]
+                modulePaths = keysSet $ modules pkg
+                target' = target $ metadata pkg
+            toImportPaths target' modulePaths `shouldBe`
+                [ "f"  -- > "f" should be added
+                , "f.oo"
+                , "f.oo.bar"
+                , "qux"
+                ]
+
+    specify "renameModulePath" $ do
+        let renames = [ (["foo"], ["poo"])
+                      , (["foo", "bar"], ["foo"])
+                      , (["baz"], ["p", "az"])
+                      ] :: RenameMap
+        renameModulePath renames ["foo"] `shouldBe` ["poo"]
+        renameModulePath renames ["foo", "baz"] `shouldBe` ["poo", "baz"]
+        renameModulePath renames ["foo", "bar"] `shouldBe` ["foo"]
+        renameModulePath renames ["foo", "bar", "qux"] `shouldBe` ["foo", "qux"]
+        renameModulePath renames ["baz"] `shouldBe` ["p", "az"]
+        renameModulePath renames ["baz", "qux"] `shouldBe` ["p", "az", "qux"]
+        renameModulePath renames ["qux", "foo"] `shouldBe` ["qux", "foo"]

--- a/test/Nirum/Targets/Python/TypeExpressionSpec.hs
+++ b/test/Nirum/Targets/Python/TypeExpressionSpec.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE QuasiQuotes #-}
+module Nirum.Targets.Python.TypeExpressionSpec where
+
+import Test.Hspec.Meta
+import Text.InterpolatedString.Perl6 (qq)
+
+import Nirum.Constructs.Module
+import Nirum.Constructs.TypeDeclaration
+import Nirum.Constructs.TypeExpression
+import Nirum.Targets.Python (Source (..))
+import Nirum.Targets.Python.CodeGen
+import Nirum.Targets.Python.CodeGenSpec hiding (spec)
+import Nirum.Targets.Python.TypeExpression
+
+spec :: Spec
+spec = pythonVersionSpecs $ \ ver -> do
+    let empty' = empty ver
+        -- run' :: CodeGen a -> (Either CompileError a, CodeGenContext)
+        run' c = runCodeGen c empty'
+        -- code :: CodeGen a -> a
+        code = either (const undefined) id . fst . run'
+
+    specify [qq|compilePrimitiveType ($ver)|] $ do
+        code (compilePrimitiveType Bool) `shouldBe` "bool"
+        code (compilePrimitiveType Bigint) `shouldBe` "int"
+        let (decimalCode, decimalContext) = run' (compilePrimitiveType Decimal)
+        decimalCode `shouldBe` Right "decimal.Decimal"
+        standardImports decimalContext `shouldBe` ["decimal"]
+        code (compilePrimitiveType Int32) `shouldBe` "int"
+        code (compilePrimitiveType Int64) `shouldBe`
+            case ver of
+                Python2 -> "numbers.Integral"
+                Python3 -> "int"
+        code (compilePrimitiveType Float32) `shouldBe` "float"
+        code (compilePrimitiveType Float64) `shouldBe` "float"
+        code (compilePrimitiveType Text) `shouldBe`
+            case ver of
+                Python2 -> "unicode"
+                Python3 -> "str"
+        code (compilePrimitiveType Binary) `shouldBe` "bytes"
+        let (dateCode, dateContext) = run' (compilePrimitiveType Date)
+        dateCode `shouldBe` Right "datetime.date"
+        standardImports dateContext `shouldBe` ["datetime"]
+        let (datetimeCode, datetimeContext) =
+                run' (compilePrimitiveType Datetime)
+        datetimeCode `shouldBe` Right "datetime.datetime"
+        standardImports datetimeContext `shouldBe` ["datetime"]
+        let (uuidCode, uuidContext) = run' (compilePrimitiveType Uuid)
+        uuidCode `shouldBe` Right "uuid.UUID"
+        standardImports uuidContext `shouldBe` ["uuid"]
+        code (compilePrimitiveType Uri) `shouldBe`
+            case ver of
+                Python2 -> "unicode"
+                Python3 -> "str"
+
+    describe [qq|compileTypeExpression ($ver)|] $ do
+        let Source { sourceModule = bm } = makeDummySource $ Module [] Nothing
+        specify "TypeIdentifier" $ do
+            let (c, ctx) = run' $
+                    compileTypeExpression bm (Just $ TypeIdentifier "bigint")
+            standardImports ctx `shouldBe` []
+            localImports ctx `shouldBe` []
+            c `shouldBe` Right "int"
+        specify "OptionModifier" $ do
+            let (c', ctx') = run' $
+                    compileTypeExpression bm (Just $ OptionModifier "int32")
+            standardImports ctx' `shouldBe` ["typing"]
+            localImports ctx' `shouldBe` []
+            c' `shouldBe` Right "typing.Optional[int]"
+        specify "SetModifier" $ do
+            let (c'', ctx'') = run' $
+                    compileTypeExpression bm (Just $ SetModifier "int32")
+            standardImports ctx'' `shouldBe` ["typing"]
+            localImports ctx'' `shouldBe` []
+            c'' `shouldBe` Right "typing.AbstractSet[int]"
+        specify "ListModifier" $ do
+            let (c''', ctx''') = run' $
+                    compileTypeExpression bm (Just $ ListModifier "int32")
+            standardImports ctx''' `shouldBe` ["typing"]
+            localImports ctx''' `shouldBe` []
+            c''' `shouldBe` Right "typing.Sequence[int]"
+        specify "MapModifier" $ do
+            let (c'''', ctx'''') = run' $
+                    compileTypeExpression bm (Just $ MapModifier "uuid" "int32")
+            standardImports ctx'''' `shouldBe` ["typing", "uuid"]
+            localImports ctx'''' `shouldBe` []
+            c'''' `shouldBe` Right "typing.Mapping[uuid.UUID, int]"

--- a/test/Nirum/Targets/PythonSpec.hs
+++ b/test/Nirum/Targets/PythonSpec.hs
@@ -2,284 +2,33 @@
              ScopedTypeVariables #-}
 module Nirum.Targets.PythonSpec where
 
-import Control.Monad (forM_)
-import Data.Either (isRight)
-import Data.Maybe (fromJust)
-
 import qualified Data.Map.Strict as M
-import qualified Data.SemVer as SV
 import System.FilePath ((</>))
 import Test.Hspec.Meta
-import Text.Email.Validate (emailAddress)
-import Text.InterpolatedString.Perl6 (q, qq)
+import Text.InterpolatedString.Perl6 (q)
 
-import Nirum.Constructs.Annotation (empty)
-import Nirum.Constructs.Identifier (Identifier)
 import Nirum.Constructs.Module (Module (Module))
-import Nirum.Constructs.ModulePath (ModulePath, fromIdentifiers)
 import Nirum.Constructs.Name (Name (Name))
-import Nirum.Constructs.TypeDeclaration ( Field (Field)
-                                        , PrimitiveTypeIdentifier (..)
-                                        , Type ( Alias
-                                               , RecordType
-                                               , UnboxedType
-                                               )
-                                        , TypeDeclaration ( Import
-                                                          , TypeDeclaration
-                                                          )
-                                        )
-import Nirum.Constructs.TypeExpression ( TypeExpression ( ListModifier
-                                                        , MapModifier
-                                                        , OptionModifier
-                                                        , SetModifier
-                                                        , TypeIdentifier
-                                                        )
-                                       )
-import Nirum.Package hiding (target)
-import Nirum.Package.Metadata ( Author (Author, email, name, uri)
-                              , Metadata ( Metadata
-                                         , authors
-                                         , target
-                                         , version
-                                         , description
-                                         , license
-                                         , keywords
-                                         )
-                              , Target (compilePackage)
-                              )
-import qualified Nirum.Package.ModuleSet as MS
-import Nirum.PackageSpec (createPackage)
-import qualified Nirum.Targets.Python as PY
-import Nirum.Targets.Python ( Source (Source)
-                            , CodeGen
-                            , CodeGenContext ( localImports
-                                             , standardImports
-                                             , thirdPartyImports
-                                             )
-                            , InstallRequires ( InstallRequires
-                                              , dependencies
-                                              , optionalDependencies
-                                              )
-                            , Python (Python)
-                            , PythonVersion (Python2, Python3)
-                            , RenameMap
-                            , addDependency
-                            , addOptionalDependency
-                            , compilePrimitiveType
-                            , compileTypeExpression
-                            , insertLocalImport
-                            , insertStandardImport
-                            , insertThirdPartyImports
-                            , insertThirdPartyImportsA
-                            , localImportsMap
-                            , minimumRuntime
-                            , parseModulePath
-                            , renameModulePath
-                            , runCodeGen
-                            , stringLiteral
-                            , toAttributeName
-                            , toClassName
-                            , toNamePair
-                            , unionInstallRequires
-                            )
-import Nirum.TypeInstance.BoundModule
-
-codeGen :: a -> CodeGen a
-codeGen = return
-
-makeDummySource' :: [Identifier] -> Module -> RenameMap -> Source
-makeDummySource' pathPrefix m renames =
-    Source pkg $ fromJust $ resolveBoundModule ["foo"] pkg
-  where
-    mp :: [Identifier] -> ModulePath
-    mp identifiers = fromJust $ fromIdentifiers (pathPrefix ++ identifiers)
-    metadata' :: Metadata Python
-    metadata' = Metadata
-        { version = SV.version 1 2 3 [] []
-        , authors =
-              [ Author
-                    { name = "John Doe"
-                    , email = Just (fromJust $ emailAddress "john@example.com")
-                    , uri = Nothing
-                    }
-              ]
-        , description = Just "Package description"
-        , license = Just "MIT"
-        , keywords = ["sample", "example", "nirum"]
-        , target = Python "sample-package" minimumRuntime renames
-        }
-    pkg :: Package Python
-    pkg = createPackage
-            metadata'
-            [ (mp ["foo"], m)
-            , ( mp ["foo", "bar"]
-              , Module [ Import (mp ["qux"]) "path" empty
-                       , TypeDeclaration "path-unbox" (UnboxedType "path") empty
-                       , TypeDeclaration "int-unbox"
-                                         (UnboxedType "bigint") empty
-                       , TypeDeclaration "point"
-                                         (RecordType [ Field "x" "int64" empty
-                                                     , Field "y" "int64" empty
-                                                     ])
-                                         empty
-                       ] Nothing
-              )
-            , ( mp ["qux"]
-              , Module
-                  [ TypeDeclaration "path" (Alias "text") empty
-                  , TypeDeclaration "name" (UnboxedType "text") empty
-                  ]
-                  Nothing
-              )
-            ]
-
-makeDummySource :: Module -> Source
-makeDummySource m = makeDummySource' [] m []
+import Nirum.Package.Metadata (Target (compilePackage))
+import Nirum.Targets.Python
+    ( Source (Source)
+    , InstallRequires
+          ( InstallRequires
+          , dependencies
+          , optionalDependencies
+          )
+    , addDependency
+    , addOptionalDependency
+    , parseModulePath
+    , stringLiteral
+    , toNamePair
+    , unionInstallRequires
+    )
+import Nirum.Targets.Python.CodeGenSpec hiding (spec)
 
 spec :: Spec
-spec = parallel $ forM_ ([Python2, Python3] :: [PythonVersion]) $ \ ver -> do
-    let empty' = PY.empty ver
-        -- run' :: CodeGen a -> (Either CompileError a, CodeGenContext)
-        run' c = runCodeGen c empty'
-        -- code :: CodeGen a -> a
-        code = either (const undefined) id . fst . run'
-        -- compileError :: CodeGen a -> Maybe CompileError
-        compileError cg = either Just (const Nothing) $ fst $
-            runCodeGen cg empty'
-    describe [qq|CodeGen ($ver)|] $ do
-        specify "packages and imports" $ do
-            let c = do
-                    insertStandardImport "sys"
-                    insertThirdPartyImports
-                        [("nirum", ["serialize_unboxed_type"])]
-                    insertLocalImport ".." "Gender"
-                    insertStandardImport "os"
-                    insertThirdPartyImports [("nirum", ["serialize_enum_type"])]
-                    insertThirdPartyImportsA
-                        [("nirum.constructs", [("name_dict_type", "NameDict")])]
-                    insertLocalImport ".." "Path"
-            let (e, ctx) = runCodeGen c empty'
-            e `shouldSatisfy` isRight
-            standardImports ctx `shouldBe` ["os", "sys"]
-            thirdPartyImports ctx `shouldBe`
-                [ ( "nirum"
-                  , [ ("serialize_unboxed_type", "serialize_unboxed_type")
-                    , ("serialize_enum_type", "serialize_enum_type")
-                    ]
-                  )
-                , ( "nirum.constructs"
-                  , [("name_dict_type", "NameDict")]
-                  )
-                ]
-            localImports ctx `shouldBe` [("..", ["Gender", "Path"])]
-            localImportsMap ctx `shouldBe`
-                [ ( ".."
-                  , [ ("Gender", "Gender")
-                    , ("Path", "Path")
-                    ]
-                  )
-                ]
-        specify "insertStandardImport" $ do
-            let codeGen1 = insertStandardImport "sys"
-            let (e1, ctx1) = runCodeGen codeGen1 empty'
-            e1 `shouldSatisfy` isRight
-            standardImports ctx1 `shouldBe` ["sys"]
-            thirdPartyImports ctx1 `shouldBe` []
-            localImports ctx1 `shouldBe` []
-            compileError codeGen1 `shouldBe` Nothing
-            let codeGen2 = codeGen1 >> insertStandardImport "os"
-            let (e2, ctx2) = runCodeGen codeGen2 empty'
-            e2 `shouldSatisfy` isRight
-            standardImports ctx2 `shouldBe` ["os", "sys"]
-            thirdPartyImports ctx2 `shouldBe` []
-            localImports ctx2 `shouldBe` []
-            compileError codeGen2 `shouldBe` Nothing
-
-    specify [qq|compilePrimitiveType ($ver)|] $ do
-        code (compilePrimitiveType Bool) `shouldBe` "bool"
-        code (compilePrimitiveType Bigint) `shouldBe` "int"
-        let (decimalCode, decimalContext) = run' (compilePrimitiveType Decimal)
-        decimalCode `shouldBe` Right "decimal.Decimal"
-        standardImports decimalContext `shouldBe` ["decimal"]
-        code (compilePrimitiveType Int32) `shouldBe` "int"
-        code (compilePrimitiveType Int64) `shouldBe`
-            case ver of
-                Python2 -> "numbers.Integral"
-                Python3 -> "int"
-        code (compilePrimitiveType Float32) `shouldBe` "float"
-        code (compilePrimitiveType Float64) `shouldBe` "float"
-        code (compilePrimitiveType Text) `shouldBe`
-            case ver of
-                Python2 -> "unicode"
-                Python3 -> "str"
-        code (compilePrimitiveType Binary) `shouldBe` "bytes"
-        let (dateCode, dateContext) = run' (compilePrimitiveType Date)
-        dateCode `shouldBe` Right "datetime.date"
-        standardImports dateContext `shouldBe` ["datetime"]
-        let (datetimeCode, datetimeContext) =
-                run' (compilePrimitiveType Datetime)
-        datetimeCode `shouldBe` Right "datetime.datetime"
-        standardImports datetimeContext `shouldBe` ["datetime"]
-        let (uuidCode, uuidContext) = run' (compilePrimitiveType Uuid)
-        uuidCode `shouldBe` Right "uuid.UUID"
-        standardImports uuidContext `shouldBe` ["uuid"]
-        code (compilePrimitiveType Uri) `shouldBe`
-            case ver of
-                Python2 -> "unicode"
-                Python3 -> "str"
-
-    describe [qq|compileTypeExpression ($ver)|] $ do
-        let s = makeDummySource $ Module [] Nothing
-        specify "TypeIdentifier" $ do
-            let (c, ctx) = run' $
-                    compileTypeExpression s (Just $ TypeIdentifier "bigint")
-            standardImports ctx `shouldBe` []
-            localImports ctx `shouldBe` []
-            c `shouldBe` Right "int"
-        specify "OptionModifier" $ do
-            let (c', ctx') = run' $
-                    compileTypeExpression s (Just $ OptionModifier "int32")
-            standardImports ctx' `shouldBe` ["typing"]
-            localImports ctx' `shouldBe` []
-            c' `shouldBe` Right "typing.Optional[int]"
-        specify "SetModifier" $ do
-            let (c'', ctx'') = run' $
-                    compileTypeExpression s (Just $ SetModifier "int32")
-            standardImports ctx'' `shouldBe` ["typing"]
-            localImports ctx'' `shouldBe` []
-            c'' `shouldBe` Right "typing.AbstractSet[int]"
-        specify "ListModifier" $ do
-            let (c''', ctx''') = run' $
-                    compileTypeExpression s (Just $ ListModifier "int32")
-            standardImports ctx''' `shouldBe` ["typing"]
-            localImports ctx''' `shouldBe` []
-            c''' `shouldBe` Right "typing.Sequence[int]"
-        specify "MapModifier" $ do
-            let (c'''', ctx'''') = run' $
-                    compileTypeExpression s (Just $ MapModifier "uuid" "int32")
-            standardImports ctx'''' `shouldBe` ["typing", "uuid"]
-            localImports ctx'''' `shouldBe` []
-            c'''' `shouldBe` Right "typing.Mapping[uuid.UUID, int]"
-
-    describe [qq|toClassName ($ver)|] $ do
-        it "transform the facial name of the argument into PascalCase" $ do
-            toClassName "test" `shouldBe` "Test"
-            toClassName "hello-world" `shouldBe` "HelloWorld"
-        it "appends an underscore to the result if it's a reserved keyword" $ do
-            toClassName "true" `shouldBe` "True_"
-            toClassName "false" `shouldBe` "False_"
-            toClassName "none" `shouldBe` "None_"
-
-    describe [qq|toAttributeName ($ver)|] $ do
-        it "transform the facial name of the argument into snake_case" $ do
-            toAttributeName "test" `shouldBe` "test"
-            toAttributeName "hello-world" `shouldBe` "hello_world"
-        it "appends an underscore to the result if it's a reserved keyword" $ do
-            toAttributeName "def" `shouldBe` "def_"
-            toAttributeName "lambda" `shouldBe` "lambda_"
-            toAttributeName "nonlocal" `shouldBe` "nonlocal_"
-
-    describe [qq|toNamePair ($ver)|] $ do
+spec = do
+    describe "toNamePair" $ do
         it "transforms the name to a Python code string of facial/behind pair" $
             do toNamePair "text" `shouldBe` "('text', 'text')"
                toNamePair (Name "test" "hello") `shouldBe` "('test', 'hello')"
@@ -293,7 +42,7 @@ spec = parallel $ forM_ ([Python2, Python3] :: [PythonVersion]) $ \ ver -> do
             toNamePair (Name "abc" "lambda") `shouldBe` "('abc', 'lambda')"
             toNamePair (Name "lambda" "abc") `shouldBe` "('lambda_', 'abc')"
 
-    specify [qq|stringLiteral ($ver)|] $ do
+    specify "stringLiteral" $ do
         stringLiteral "asdf" `shouldBe` [q|"asdf"|]
         stringLiteral [q|Say 'hello world'|]
             `shouldBe` [q|"Say 'hello world'"|]
@@ -302,7 +51,7 @@ spec = parallel $ forM_ ([Python2, Python3] :: [PythonVersion]) $ \ ver -> do
         stringLiteral "Say '\xc548\xb155'"
             `shouldBe` [q|u"Say '\uc548\ub155'"|]
 
-    describe [qq|compilePackage ($ver)|] $ do
+    describe "compilePackage" $ do
         it "returns a Map of file paths and their contents to generate" $ do
             let (Source pkg _) = makeDummySource $ Module [] Nothing
                 files = compilePackage pkg
@@ -364,7 +113,7 @@ spec = parallel $ forM_ ([Python2, Python3] :: [PythonVersion]) $ \ ver -> do
                     ]
             M.keysSet files' `shouldBe` directoryStructure'
 
-    describe [qq|InstallRequires ($ver)|] $ do
+    describe "InstallRequires" $ do
         let req = InstallRequires [] []
             req2 = req { dependencies = ["six"] }
             req3 = req { optionalDependencies = [((3, 4), ["enum34"])] }
@@ -407,31 +156,7 @@ spec = parallel $ forM_ ([Python2, Python3] :: [PythonVersion]) $ \ ver -> do
                                              (3, 4) "ipaddress"
             (req4 `unionInstallRequires` req5) `shouldBe` req6
             (req5 `unionInstallRequires` req4) `shouldBe` req6
-    specify [qq|toImportPath ($ver)|] $ do
-        let (Source pkg _) = makeDummySource $ Module [] Nothing
-            target' = target $ metadata pkg
-        PY.toImportPath target' ["foo", "bar"] `shouldBe` "foo.bar"
-    describe [qq|toImportPath ($ver)|] $ do
-        it "adds ancestors of packages" $ do
-            let (Source pkg _) = makeDummySource $ Module [] Nothing
-                modulePaths = MS.keysSet $ modules pkg
-                target' = target $ metadata pkg
-            PY.toImportPaths target' modulePaths `shouldBe`
-                [ "foo"
-                , "foo.bar"
-                , "qux"
-                ]
-        it "applies renames before add ancestors of packages" $ do
-            let (Source pkg _) = makeDummySource' [] (Module [] Nothing)
-                                                  [(["foo"], ["f", "oo"])]
-                modulePaths = MS.keysSet $ modules pkg
-                target' = target $ metadata pkg
-            PY.toImportPaths target' modulePaths `shouldBe`
-                [ "f"  -- > "f" should be added
-                , "f.oo"
-                , "f.oo.bar"
-                , "qux"
-                ]
+
     specify "parseModulePath" $ do
         parseModulePath "" `shouldBe` Nothing
         parseModulePath "foo" `shouldBe` Just ["foo"]
@@ -444,15 +169,3 @@ spec = parallel $ forM_ ([Python2, Python3] :: [PythonVersion]) $ \ ver -> do
         parseModulePath "foo..bar" `shouldBe` Nothing
         parseModulePath "foo.bar>" `shouldBe` Nothing
         parseModulePath "foo.bar-" `shouldBe` Nothing
-    specify "renameModulePath" $ do
-        let renames = [ (["foo"], ["poo"])
-                      , (["foo", "bar"], ["foo"])
-                      , (["baz"], ["p", "az"])
-                      ] :: RenameMap
-        renameModulePath renames ["foo"] `shouldBe` ["poo"]
-        renameModulePath renames ["foo", "baz"] `shouldBe` ["poo", "baz"]
-        renameModulePath renames ["foo", "bar"] `shouldBe` ["foo"]
-        renameModulePath renames ["foo", "bar", "qux"] `shouldBe` ["foo", "qux"]
-        renameModulePath renames ["baz"] `shouldBe` ["p", "az"]
-        renameModulePath renames ["baz", "qux"] `shouldBe` ["p", "az", "qux"]
-        renameModulePath renames ["qux", "foo"] `shouldBe` ["qux", "foo"]

--- a/test/Nirum/TypeInstance/BoundModuleSpec.hs
+++ b/test/Nirum/TypeInstance/BoundModuleSpec.hs
@@ -15,7 +15,8 @@ import Nirum.Constructs.TypeDeclaration hiding (modulePath)
 import Nirum.Package.Metadata
 import Nirum.Package.MetadataSpec
 import Nirum.PackageSpec (createValidPackage)
-import Nirum.Targets.Python (Python (Python), minimumRuntime)
+import Nirum.Targets.Python (Python (Python))
+import Nirum.Targets.Python.CodeGen (minimumRuntime)
 import Nirum.TypeInstance.BoundModule
 
 spec :: Spec


### PR DESCRIPTION
As `Nirum.Targets.Python` had been too large to be left as a single module, I divide it into several submodules.  This kind of module dividing could be done more from now on.

Note that I added *Python.hs-boot* file as well.  It's like a header file which consists of forward declarations in C/C++.  With `{-# SOURCE #-}` pragma annotated `import` statements, it breaks a cycle of module dependency.  See also the related chapter in the GHC User's Guide: [*How to compile mutually recursive modules*][1].

[1]: https://downloads.haskell.org/~ghc/8.2.2/docs/html/users_guide/separate_compilation.html#how-to-compile-mutually-recursive-modules