### PR TITLE
Make generated Python codes free from validate_*() runtime functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 __pycache__
 .cache
+.pytest_cache
 .stack-work
 *.tix
 *.pyc

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -55,6 +55,7 @@
     within:
     - Nirum.Parser
     - Nirum.ParserSpec
+    - Nirum.Targets.Python.CodeGenSpec
 - ignore: {name: Unnecessary hiding}
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,7 @@ before_install:
     brew update || true
     brew upgrade || true
     brew update || true
+    brew install --with-default-names gnu-sed
     brew tap dahlia/homebrew-deadsnakes
     brew install python34 python35 python3 || \
       brew upgrade python34 python35 python3 || \

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,7 +34,11 @@ To be released.
     (``tzinfo``) awareness check for `datetime`, and basic format check for
     `uri`.
 
+ -  Fixed a bug that generated service methods hadn't checked its arguments
+    before its transport sends a payload.  [[#220]]
+
 [#13]: https://github.com/spoqa/nirum/issues/13
+[#220]: https://github.com/spoqa/nirum/issues/220
 [#227]: https://github.com/spoqa/nirum/pull/227
 [entry points]: https://setuptools.readthedocs.io/en/latest/pkg_resources.html#entry-points
 [python-basestring]: https://docs.python.org/2/library/functions.html#basestring

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,11 @@ To be released.
  -  Fixed a bug that generated service methods hadn't checked its arguments
     before its transport sends a payload.  [[#220]]
 
+ -  Fixed a bug that field/parameter names that use a module name of the Python
+    standard library cause runtime `TypeError`s (due to name shadowing).
+    Under the hood, all generated `import`s are now aliased with a name prefixed
+    an underscore.
+
 [#13]: https://github.com/spoqa/nirum/issues/13
 [#220]: https://github.com/spoqa/nirum/issues/220
 [#227]: https://github.com/spoqa/nirum/pull/227

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,9 +23,22 @@ To be released.
         classes.  Nirum type names are qualified and their leading module paths
         are also normalized (the same rule to `nirum.modules` applies here).
 
+ -  The `uri` type became represented as [`basestring`][python-basestring]
+    instead of [`unicode`][python-unicode] in Python 2, since URI (unlike IRI)
+    is limited to a subset of ASCII character set.
+
+    There's no change to Python 3.
+
+ -  Generated type constructors became to validate field value's range or format
+    besides class checks: range checks for `int32`/`int64`, time zone
+    (``tzinfo``) awareness check for `datetime`, and basic format check for
+    `uri`.
+
 [#13]: https://github.com/spoqa/nirum/issues/13
 [#227]: https://github.com/spoqa/nirum/pull/227
 [entry points]: https://setuptools.readthedocs.io/en/latest/pkg_resources.html#entry-points
+[python-basestring]: https://docs.python.org/2/library/functions.html#basestring
+[python-unicode]: https://docs.python.org/2/library/functions.html#unicode
 
 
 Version 0.3.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,8 +23,14 @@ To be released.
         classes.  Nirum type names are qualified and their leading module paths
         are also normalized (the same rule to `nirum.modules` applies here).
 
- -  The `uri` type became represented as [`basestring`][python-basestring]
-    instead of [`unicode`][python-unicode] in Python 2, since URI (unlike IRI)
+ -  All integral types (`int32`, `int64`, and `bigint`) became represented
+    as [`numbers.Integral`][python2-numbers-integral] instead of
+    [`int`][python2-int].
+
+    There's no change to Python 3.
+
+ -  The `uri` type became represented as [`basestring`][python2-basestring]
+    instead of [`unicode`][python2-unicode] in Python 2, since URI (unlike IRI)
     is limited to a subset of ASCII character set.
 
     There's no change to Python 3.
@@ -46,8 +52,9 @@ To be released.
 [#220]: https://github.com/spoqa/nirum/issues/220
 [#227]: https://github.com/spoqa/nirum/pull/227
 [entry points]: https://setuptools.readthedocs.io/en/latest/pkg_resources.html#entry-points
-[python-basestring]: https://docs.python.org/2/library/functions.html#basestring
-[python-unicode]: https://docs.python.org/2/library/functions.html#unicode
+[python2-numbers-integral]: https://docs.python.org/2/library/numbers.html#numbers.Integral
+[python2-basestring]: https://docs.python.org/2/library/functions.html#basestring
+[python2-unicode]: https://docs.python.org/2/library/functions.html#unicode
 
 
 Version 0.3.1

--- a/src/Nirum/Targets/Python/TypeExpression.hs
+++ b/src/Nirum/Targets/Python/TypeExpression.hs
@@ -33,12 +33,12 @@ compileTypeExpression mod' (Just (TypeIdentifier i)) =
 compileTypeExpression mod' (Just (MapModifier k v)) = do
     kExpr <- compileTypeExpression mod' (Just k)
     vExpr <- compileTypeExpression mod' (Just v)
-    insertStandardImport "typing"
-    return [qq|typing.Mapping[$kExpr, $vExpr]|]
+    typing <- importStandardLibrary "typing"
+    return [qq|$typing.Mapping[$kExpr, $vExpr]|]
 compileTypeExpression mod' (Just modifier) = do
     expr <- compileTypeExpression mod' (Just typeExpr)
-    insertStandardImport "typing"
-    return [qq|typing.$className[$expr]|]
+    typing <- importStandardLibrary "typing"
+    return [qq|$typing.$className[$expr]|]
   where
     typeExpr :: TypeExpression
     className :: Text
@@ -55,27 +55,34 @@ compilePrimitiveType :: PrimitiveTypeIdentifier -> CodeGen Code
 compilePrimitiveType primitiveTypeIdentifier' = do
     pyVer <- getPythonVersion
     case (primitiveTypeIdentifier', pyVer) of
-        (Bool, _) -> return "bool"
-        (Bigint, _) -> return "int"
+        (Bool, _) -> builtins "bool"
+        (Bigint, _) -> builtins "int"
         (Decimal, _) -> do
-            insertStandardImport "decimal"
-            return "decimal.Decimal"
-        (Int32, _) -> return "int"
+            decimal <- importStandardLibrary "decimal"
+            return [qq|$decimal.Decimal|]
+        (Int32, _) -> builtins "int"
         (Int64, Python2) -> do
-            insertStandardImport "numbers"
-            return "numbers.Integral"
-        (Int64, Python3) -> return "int"
-        (Float32, _) -> return "float"
-        (Float64, _) -> return "float"
-        (Text, Python2) -> return "unicode"
-        (Text, Python3) -> return "str"
-        (Binary, _) -> return "bytes"
+            numbers <- importStandardLibrary "numbers"
+            return [qq|$numbers.Integral|]
+        (Int64, Python3) -> builtins "int"
+        (Float32, _) -> builtins "float"
+        (Float64, _) -> builtins "float"
+        (Text, Python2) -> builtins "unicode"
+        (Text, Python3) -> builtins "str"
+        (Binary, _) -> builtins "bytes"
         (Date, _) -> do
-            insertStandardImport "datetime"
-            return "datetime.date"
+            datetime <- importStandardLibrary "datetime"
+            return [qq|$datetime.date|]
         (Datetime, _) -> do
-            insertStandardImport "datetime"
-            return "datetime.datetime"
-        (Uuid, _) -> insertStandardImport "uuid" >> return "uuid.UUID"
-        (Uri, Python2) -> return "basestring"
-        (Uri, Python3) -> return "str"
+            datetime <- importStandardLibrary "datetime"
+            return [qq|$datetime.datetime|]
+        (Uuid, _) -> do
+            uuid <- importStandardLibrary "uuid"
+            return [qq|$uuid.UUID|]
+        (Uri, Python2) -> builtins "basestring"
+        (Uri, Python3) -> builtins "str"
+  where
+    builtins :: Code -> CodeGen Code
+    builtins typename' = do
+        builtinsMod <- importBuiltins
+        return [qq|$builtinsMod.$typename'|]

--- a/src/Nirum/Targets/Python/TypeExpression.hs
+++ b/src/Nirum/Targets/Python/TypeExpression.hs
@@ -77,5 +77,5 @@ compilePrimitiveType primitiveTypeIdentifier' = do
             insertStandardImport "datetime"
             return "datetime.datetime"
         (Uuid, _) -> insertStandardImport "uuid" >> return "uuid.UUID"
-        (Uri, Python2) -> return "unicode"
+        (Uri, Python2) -> return "basestring"
         (Uri, Python3) -> return "str"

--- a/src/Nirum/Targets/Python/TypeExpression.hs
+++ b/src/Nirum/Targets/Python/TypeExpression.hs
@@ -56,15 +56,15 @@ compilePrimitiveType primitiveTypeIdentifier' = do
     pyVer <- getPythonVersion
     case (primitiveTypeIdentifier', pyVer) of
         (Bool, _) -> builtins "bool"
-        (Bigint, _) -> builtins "int"
+        (Bigint, Python2) -> do
+            numbers <- importStandardLibrary "numbers"
+            return [qq|$numbers.Integral|]
+        (Bigint, Python3) -> builtins "int"
         (Decimal, _) -> do
             decimal <- importStandardLibrary "decimal"
             return [qq|$decimal.Decimal|]
-        (Int32, _) -> builtins "int"
-        (Int64, Python2) -> do
-            numbers <- importStandardLibrary "numbers"
-            return [qq|$numbers.Integral|]
-        (Int64, Python3) -> builtins "int"
+        (Int32, _) -> compilePrimitiveType Bigint
+        (Int64, _) -> compilePrimitiveType Bigint
         (Float32, _) -> builtins "float"
         (Float64, _) -> builtins "float"
         (Text, Python2) -> builtins "unicode"

--- a/src/Nirum/Targets/Python/Validators.hs
+++ b/src/Nirum/Targets/Python/Validators.hs
@@ -116,11 +116,9 @@ compileInstanceValidator mod' typeId pythonVar = do
 collectionsAbc :: CodeGen Code
 collectionsAbc = do
     ver <- getPythonVersion
-    let abc = case ver of
-                  Python2 -> "collections"
-                  Python3 -> "collections.abc"
-    insertStandardImport abc
-    return abc
+    importStandardLibrary $ case ver of
+        Python2 -> "collections"
+        Python3 -> "collections.abc"
 
 multiplexValidators :: BoundModule Python
                     -> Code

--- a/src/Nirum/Targets/Python/Validators.hs
+++ b/src/Nirum/Targets/Python/Validators.hs
@@ -1,0 +1,148 @@
+{-# LANGUAGE QuasiQuotes #-}
+module Nirum.Targets.Python.Validators
+    ( Validator (..)
+    , ValueValidator (..)
+    , compilePrimitiveTypeValidator
+    , compileValidator
+    ) where
+
+import Data.Text (Text, intercalate)
+import Text.InterpolatedString.Perl6 (qq)
+
+import Nirum.Constructs.Identifier
+import Nirum.Constructs.TypeDeclaration
+import Nirum.Constructs.TypeExpression
+import {-# SOURCE #-} Nirum.Targets.Python ()
+import Nirum.Targets.Python.CodeGen
+import Nirum.Targets.Python.TypeExpression
+import Nirum.TypeInstance.BoundModule
+
+data Validator = Validator
+    { typePredicateCode :: Code
+    , valueValidators :: [ValueValidator]
+    } deriving (Eq, Show)
+
+data ValueValidator = ValueValidator
+    { predicateCode :: Code
+    , errorMessage :: Text
+    } deriving (Eq, Show)
+
+compileValidator :: BoundModule Python
+                 -> TypeExpression
+                 -> Code
+                 -> CodeGen Validator
+compileValidator mod' (OptionModifier typeExpr) pythonVar = do
+    Validator typePred vvs <- compileValidator mod' typeExpr pythonVar
+    let typeValidator = [qq|(($pythonVar) is None or $typePred)|]
+        valueValidators' =
+            [ ValueValidator [qq|(($pythonVar) is None or ($vPredCode))|] msg
+            | ValueValidator vPredCode msg <- vvs
+            ]
+    return $ Validator typeValidator valueValidators'
+compileValidator mod' (SetModifier typeExpr) pythonVar = do
+    abc <- collectionsAbc
+    Validator typePred vvs <-
+        multiplexValidators mod' pythonVar [(typeExpr, "elem")]
+    return $ Validator
+        [qq|(isinstance($pythonVar, $abc.Set) and $typePred)|]
+        vvs
+compileValidator mod' (ListModifier typeExpr) pythonVar = do
+    abc <- collectionsAbc
+    Validator typePred vvs <-
+        multiplexValidators mod' pythonVar [(typeExpr, "item")]
+    return $ Validator
+        [qq|(isinstance($pythonVar, $abc.Sequence) and $typePred)|]
+        vvs
+compileValidator mod' (MapModifier keyTypeExpr valueTypeExpr) pythonVar = do
+    abc <- collectionsAbc
+    Validator typePred vvs <-
+        multiplexValidators mod' [qq|(($pythonVar).items())|]
+        [(keyTypeExpr, "key"), (valueTypeExpr, "value")]
+    return $ Validator
+        [qq|(isinstance($pythonVar, $abc.Mapping) and $typePred)|]
+        vvs
+compileValidator mod' (TypeIdentifier typeId) pythonVar =
+    case lookupType typeId mod' of
+        Missing -> return $ Validator "False" []  -- must never happen
+        Local (Alias typeExpr') -> compileValidator mod' typeExpr' pythonVar
+        Imported modulePath' (Alias typeExpr') ->
+            case resolveBoundModule modulePath' (boundPackage mod') of
+                Nothing -> return $ Validator "False" []  -- must never happen
+                Just foundMod -> compileValidator foundMod typeExpr' pythonVar
+        Local PrimitiveType { primitiveTypeIdentifier = pId } ->
+            compilePrimitiveTypeValidator pId pythonVar
+        Imported _ PrimitiveType { primitiveTypeIdentifier = pId } ->
+            compilePrimitiveTypeValidator pId pythonVar
+        _ ->
+            compileInstanceValidator mod' typeId pythonVar
+
+compilePrimitiveTypeValidator :: PrimitiveTypeIdentifier
+                              -> Code
+                              -> CodeGen Validator
+compilePrimitiveTypeValidator primitiveTypeId pythonVar = do
+    typeName <- compilePrimitiveType primitiveTypeId
+    return $ Validator
+        [qq|(isinstance(($pythonVar), ($typeName)))|]
+        (vv primitiveTypeId pythonVar)
+  where
+    vv :: PrimitiveTypeIdentifier -> Code -> [ValueValidator]
+    vv Int32 var =
+        [ ValueValidator [qq|(-0x80000000 <= ($var) < 0x80000000)|]
+                         "out of range of 32-bit integer"
+        ]
+    vv Int64 var =
+        [ ValueValidator
+              [qq|(-0x8000000000000000 <= ($var) < 0x8000000000000000)|]
+              "out of range of 64-bit integer"
+        ]
+    vv Datetime var =
+        [ ValueValidator [qq|(($var).tzinfo is not None)|]
+                         "naive datetime (lacking tzinfo)"
+        ]
+    vv Uri var =
+        [ ValueValidator [qq|('\\n' not in ($var))|]
+                         "URI cannot contain new line characters"
+        ]
+    vv _ _ = []
+
+compileInstanceValidator :: BoundModule Python
+                         -> Identifier
+                         -> Code
+                         -> CodeGen Validator
+compileInstanceValidator mod' typeId pythonVar = do
+    cls <- compileTypeExpression mod' (Just (TypeIdentifier typeId))
+    return $ Validator [qq|(isinstance(($pythonVar), ($cls)))|] []
+
+collectionsAbc :: CodeGen Code
+collectionsAbc = do
+    ver <- getPythonVersion
+    let abc = case ver of
+                  Python2 -> "collections"
+                  Python3 -> "collections.abc"
+    insertStandardImport abc
+    return abc
+
+multiplexValidators :: BoundModule Python
+                    -> Code
+                    -> [(TypeExpression, Code)]
+                    -> CodeGen Validator
+multiplexValidators mod' iterableExpr elements = do
+    validators <- sequence
+        [ do
+              v <- compileValidator mod' tExpr elemVar
+              return (elemVar, v)
+        | (tExpr, var) <- elements
+        , elemVar <- [mangleVar iterableExpr var]
+        ]
+    let csElemVars = intercalate "," [v | (v, _) <- validators]
+        typePredLogicalAnds = intercalate
+            " and "
+            [typePred | (_, Validator typePred _) <- validators]
+    return $ Validator
+        [qq|(all(($typePredLogicalAnds) for ($csElemVars) in $iterableExpr))|]
+        [ ValueValidator
+              [qq|(all(($typePred) for ($csElemVars) in $iterableExpr))|]
+              [qq|invalid elements ($msg)|]
+        | (_, Validator _ vvs) <- validators
+        , ValueValidator typePred msg <- vvs
+        ]

--- a/test/Nirum/Targets/Python/TypeExpressionSpec.hs
+++ b/test/Nirum/Targets/Python/TypeExpressionSpec.hs
@@ -51,7 +51,7 @@ spec = pythonVersionSpecs $ \ ver -> do
         standardImports uuidContext `shouldBe` ["uuid"]
         code (compilePrimitiveType Uri) `shouldBe`
             case ver of
-                Python2 -> "unicode"
+                Python2 -> "basestring"
                 Python3 -> "str"
 
     describe [qq|compileTypeExpression ($ver)|] $ do

--- a/test/Nirum/Targets/Python/TypeExpressionSpec.hs
+++ b/test/Nirum/Targets/Python/TypeExpressionSpec.hs
@@ -20,69 +20,82 @@ spec = pythonVersionSpecs $ \ ver -> do
         run' c = runCodeGen c empty'
         -- code :: CodeGen a -> a
         code = either (const undefined) id . fst . run'
+        builtinsPair =
+            ( "__builtin__"
+            , case ver of
+                  Python2 -> "__builtin__"
+                  Python3 -> "builtins"
+            )
 
     specify [qq|compilePrimitiveType ($ver)|] $ do
-        code (compilePrimitiveType Bool) `shouldBe` "bool"
-        code (compilePrimitiveType Bigint) `shouldBe` "int"
+        let (boolCode, boolContext) = run' $ compilePrimitiveType Bool
+        boolCode `shouldBe` Right "__builtin__.bool"
+        standardImports boolContext `shouldBe` [builtinsPair]
+        code (compilePrimitiveType Bigint) `shouldBe` "__builtin__.int"
         let (decimalCode, decimalContext) = run' (compilePrimitiveType Decimal)
-        decimalCode `shouldBe` Right "decimal.Decimal"
-        standardImports decimalContext `shouldBe` ["decimal"]
-        code (compilePrimitiveType Int32) `shouldBe` "int"
+        decimalCode `shouldBe` Right "_decimal.Decimal"
+        standardImports decimalContext `shouldBe` [("_decimal", "decimal")]
+        code (compilePrimitiveType Int32) `shouldBe` "__builtin__.int"
         code (compilePrimitiveType Int64) `shouldBe`
             case ver of
-                Python2 -> "numbers.Integral"
-                Python3 -> "int"
-        code (compilePrimitiveType Float32) `shouldBe` "float"
-        code (compilePrimitiveType Float64) `shouldBe` "float"
+                Python2 -> "_numbers.Integral"
+                Python3 -> "__builtin__.int"
+        code (compilePrimitiveType Float32) `shouldBe` "__builtin__.float"
+        code (compilePrimitiveType Float64) `shouldBe` "__builtin__.float"
         code (compilePrimitiveType Text) `shouldBe`
             case ver of
-                Python2 -> "unicode"
-                Python3 -> "str"
-        code (compilePrimitiveType Binary) `shouldBe` "bytes"
+                Python2 -> "__builtin__.unicode"
+                Python3 -> "__builtin__.str"
+        code (compilePrimitiveType Binary) `shouldBe` "__builtin__.bytes"
         let (dateCode, dateContext) = run' (compilePrimitiveType Date)
-        dateCode `shouldBe` Right "datetime.date"
-        standardImports dateContext `shouldBe` ["datetime"]
+        dateCode `shouldBe` Right "_datetime.date"
+        standardImports dateContext `shouldBe` [("_datetime", "datetime")]
         let (datetimeCode, datetimeContext) =
                 run' (compilePrimitiveType Datetime)
-        datetimeCode `shouldBe` Right "datetime.datetime"
-        standardImports datetimeContext `shouldBe` ["datetime"]
+        datetimeCode `shouldBe` Right "_datetime.datetime"
+        standardImports datetimeContext `shouldBe` [("_datetime", "datetime")]
         let (uuidCode, uuidContext) = run' (compilePrimitiveType Uuid)
-        uuidCode `shouldBe` Right "uuid.UUID"
-        standardImports uuidContext `shouldBe` ["uuid"]
+        uuidCode `shouldBe` Right "_uuid.UUID"
+        standardImports uuidContext `shouldBe` [("_uuid", "uuid")]
         code (compilePrimitiveType Uri) `shouldBe`
             case ver of
-                Python2 -> "basestring"
-                Python3 -> "str"
+                Python2 -> "__builtin__.basestring"
+                Python3 -> "__builtin__.str"
 
     describe [qq|compileTypeExpression ($ver)|] $ do
         let Source { sourceModule = bm } = makeDummySource $ Module [] Nothing
         specify "TypeIdentifier" $ do
             let (c, ctx) = run' $
                     compileTypeExpression bm (Just $ TypeIdentifier "bigint")
-            standardImports ctx `shouldBe` []
+            standardImports ctx `shouldBe` [builtinsPair]
             localImports ctx `shouldBe` []
-            c `shouldBe` Right "int"
+            c `shouldBe` Right "__builtin__.int"
         specify "OptionModifier" $ do
             let (c', ctx') = run' $
-                    compileTypeExpression bm (Just $ OptionModifier "int32")
-            standardImports ctx' `shouldBe` ["typing"]
+                    compileTypeExpression bm (Just $ OptionModifier "binary")
+            standardImports ctx' `shouldBe`
+                [builtinsPair, ("_typing", "typing")]
             localImports ctx' `shouldBe` []
-            c' `shouldBe` Right "typing.Optional[int]"
+            c' `shouldBe` Right "_typing.Optional[__builtin__.bytes]"
         specify "SetModifier" $ do
             let (c'', ctx'') = run' $
                     compileTypeExpression bm (Just $ SetModifier "int32")
-            standardImports ctx'' `shouldBe` ["typing"]
+            standardImports ctx'' `shouldBe`
+                [builtinsPair, ("_typing", "typing")]
             localImports ctx'' `shouldBe` []
-            c'' `shouldBe` Right "typing.AbstractSet[int]"
+            c'' `shouldBe` Right "_typing.AbstractSet[__builtin__.int]"
         specify "ListModifier" $ do
             let (c''', ctx''') = run' $
                     compileTypeExpression bm (Just $ ListModifier "int32")
-            standardImports ctx''' `shouldBe` ["typing"]
+            standardImports ctx''' `shouldBe`
+                [builtinsPair, ("_typing", "typing")]
             localImports ctx''' `shouldBe` []
-            c''' `shouldBe` Right "typing.Sequence[int]"
+            c''' `shouldBe` Right "_typing.Sequence[__builtin__.int]"
         specify "MapModifier" $ do
             let (c'''', ctx'''') = run' $
                     compileTypeExpression bm (Just $ MapModifier "uuid" "int32")
-            standardImports ctx'''' `shouldBe` ["typing", "uuid"]
+            standardImports ctx'''' `shouldBe`
+                [builtinsPair, ("_typing", "typing"), ("_uuid", "uuid")]
             localImports ctx'''' `shouldBe` []
-            c'''' `shouldBe` Right "typing.Mapping[uuid.UUID, int]"
+            c'''' `shouldBe`
+                Right "_typing.Mapping[_uuid.UUID, __builtin__.int]"

--- a/test/nirum_fixture/fixture/foo.nrm
+++ b/test/nirum_fixture/fixture/foo.nrm
@@ -133,3 +133,11 @@ service sample-service (
 record record-with-map (
     {text: text} text-to-text,
 );
+
+record name-shadowing-field-record (
+    {text: [text]} typing,
+    {text: {text}} collections,
+    bigint numbers,
+    uuid uuid,
+    binary bytes,
+);

--- a/test/nirum_fixture/fixture/types.nrm
+++ b/test/nirum_fixture/fixture/types.nrm
@@ -1,1 +1,5 @@
-record uuid-list ([uuid] values);
+unboxed uuid-list ([uuid]);
+
+unboxed int32-unboxed (int32);
+
+unboxed datetime-unboxed (datetime);

--- a/test/python/primitive_test.py
+++ b/test/python/primitive_test.py
@@ -126,6 +126,7 @@ top: invalid literal for int() with base 10: 'b'\
         Point1(left='a', top=1)
     with raises(TypeError):
         Point1(left='a', top='b')
+    assert repr(point) == 'fixture.foo.Point1(left=3, top=14)'
     assert isinstance(Point2, type)
     int_three = IntUnbox(3)
     int_four_teen = IntUnbox(14)
@@ -159,6 +160,10 @@ top: invalid literal for int() with base 10: 'b'\
         Point2(left=IntUnbox(1), top='a')
     with raises(TypeError):
         Point2(left=IntUnbox(1), top=2)
+    assert repr(point2) == (
+        'fixture.foo.Point2(left=fixture.foo.bar.IntUnbox(3), '
+        'top=fixture.foo.bar.IntUnbox(14))'
+    )
     assert isinstance(Point3d, type)
     point3d = Point3d(xy=Point(x=1, y=2), z=3)
     assert point3d.xy == Point(x=1, y=2)
@@ -174,6 +179,8 @@ top: invalid literal for int() with base 10: 'b'\
     }
     assert point3d.__nirum_serialize__() == point3d_serialize
     assert Point3d.__nirum_deserialize__(point3d_serialize) == point3d
+    assert (repr(point3d) ==
+            'fixture.foo.Point3d(xy=fixture.foo.bar.Point(x=1, y=2), z=3)')
 
     # Optional fields can be empty
     r = RecordWithOptionalRecordField(f=None)

--- a/test/python/primitive_test.py
+++ b/test/python/primitive_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import enum
+import uuid
 
 from pytest import raises
 from nirum.service import Service
@@ -17,6 +18,7 @@ from fixture.foo import (Album, CultureAgnosticName, Dog,
                          WesternName)
 from fixture.foo.bar import PathUnbox, IntUnbox, Point
 from fixture.qux import Path, Name
+from fixture.types import UuidList
 
 
 def test_float_unbox():
@@ -67,6 +69,20 @@ def test_boxed_alias():
     assert Irum(u'khj').__nirum_serialize__() == u'khj'
     assert Irum.__nirum_deserialize__(u'khj') == Name(u'khj')
     assert Irum.__nirum_deserialize__(u'khj') == Irum(u'khj')
+
+
+def test_unboxed_list():
+    assert list(UuidList([]).value) == []
+    uuids = [uuid.uuid1() for _ in range(3)]
+    assert list(UuidList(uuids).value) == uuids
+    with raises(TypeError) as ei:
+        UuidList(['not uuid'])
+    assert (str(ei.value) ==
+            "expected typing.Sequence[uuid.UUID], not ['not uuid']")
+    with raises(TypeError) as ei:
+        UuidList(uuids + ['not uuid'])
+    assert str(ei.value) == \
+        "expected typing.Sequence[uuid.UUID], not %r" % (uuids + ['not uuid'])
 
 
 def test_enum():

--- a/test/python/primitive_test.py
+++ b/test/python/primitive_test.py
@@ -29,8 +29,8 @@ def test_float_unbox():
     assert {float_unbox, float_unbox, float1} == {float_unbox, float1}
     assert float_unbox.__nirum_serialize__() == 3.14
     assert FloatUnbox.__nirum_deserialize__(3.14) == float_unbox
-    assert hash(float_unbox)
-    assert hash(float_unbox) != 3.14
+    assert hash(float_unbox) == hash(FloatUnbox(3.14))
+    assert hash(float_unbox) != hash(float1)
     with raises(ValueError):
         FloatUnbox.__nirum_deserialize__('a')
     with raises(TypeError):
@@ -102,7 +102,9 @@ def test_record():
     assert point != Point1(left=4, top=14)
     assert point != Point1(left=4, top=15)
     assert point != 'foo'
-    assert hash(Point1(left=3, top=14))
+    assert hash(point) == hash(Point1(left=3, top=14))
+    assert hash(point) != hash(Point1(left=0, top=14))
+    assert hash(point) != hash(Point1(left=3, top=0))
     point_serialized = {'_type': 'point1', 'x': 3, 'top': 14}
     assert point.__nirum_serialize__() == point_serialized
     assert Point1.__nirum_deserialize__(point_serialized) == point
@@ -135,6 +137,9 @@ top: invalid literal for int() with base 10: 'b'\
     assert point2 != Point2(left=IntUnbox(4), top=IntUnbox(14))
     assert point2 != Point2(left=IntUnbox(4), top=IntUnbox(15))
     assert point2 != 'foo'
+    assert hash(point2) == hash(Point2(left=IntUnbox(3), top=IntUnbox(14)))
+    assert hash(point2) != hash(Point2(left=IntUnbox(0), top=IntUnbox(14)))
+    assert hash(point2) != hash(Point2(left=IntUnbox(3), top=IntUnbox(0)))
     point2_serialize = {'_type': 'point2', 'left': 3, 'top': 14}
     assert point2.__nirum_serialize__() == point2_serialize
     assert Point2.__nirum_deserialize__(point2_serialize) == point2
@@ -228,7 +233,16 @@ def test_union():
                                        middle_name=u'wrong',
                                        last_name=u'wrong')
     assert hash(WesternName(first_name=u'foo', middle_name=u'bar',
-                            last_name=u'baz'))
+                            last_name=u'baz')) == hash(western_name)
+    assert hash(western_name) != hash(
+        WesternName(first_name=u'', middle_name=u'bar', last_name=u'baz')
+    )
+    assert hash(western_name) != hash(
+        WesternName(first_name=u'foo', middle_name=u'', last_name=u'baz')
+    )
+    assert hash(western_name) != hash(
+        WesternName(first_name=u'foo', middle_name=u'bar', last_name=u'')
+    )
     if PY3:
         assert repr(western_name) == (
             "fixture.foo.MixedName.WesternName(first_name='foo', "

--- a/test/python/validation_test.py
+++ b/test/python/validation_test.py
@@ -1,0 +1,51 @@
+import datetime
+
+from pytest import raises
+
+from fixture.foo import Product
+from fixture.foo.bar import Point
+from fixture.types import DatetimeUnboxed, Int32Unboxed
+
+
+try:
+    UTC = datetime.timezone.utc
+except AttributeError:
+    from dateutil.tz import tzutc
+    UTC = tzutc()
+
+
+def test_int32_value_error():
+    Int32Unboxed(0)
+    Int32Unboxed(2 ** 15)
+    Int32Unboxed(2 ** 31 - 1)
+    Int32Unboxed(-(2 ** 31))
+    with raises(ValueError):
+        Int32Unboxed(2 ** 31)
+    with raises(ValueError):
+        Int32Unboxed(-(2 ** 31 + 1))
+
+
+def test_int64_value_error():
+    Point(x=0, y=0)
+    Point(x=2 ** 31, y=0)
+    Point(x=2 ** 63 - 1, y=0)
+    Point(x=-(2 ** 63), y=0)
+    with raises(ValueError):
+        Point(x=2 ** 63, y=0)
+    with raises(ValueError):
+        Point(x=-(2 ** 63 + 1), y=0)
+
+
+def test_datetime_value_error():
+    DatetimeUnboxed(datetime.datetime(2018, 3, 11, 5, 27, tzinfo=UTC))
+    with raises(ValueError):
+        # Naive datetime is disallowed
+        DatetimeUnboxed(datetime.datetime(2018, 3, 11, 5, 27))
+
+
+def test_uri_value_error():
+    Product(name=u'', sale=True, url=None)  # url field is optional here
+    Product(name=u'', sale=True, url='http://example.com/')
+    with raises(ValueError):
+        # URI cannot contain new lines
+        Product(name=u'', sale=True, url='http://example.com/\n')

--- a/test/serialization/primitive-types/uuid.json
+++ b/test/serialization/primitive-types/uuid.json
@@ -1,22 +1,16 @@
 {
     "description": "Although UUID strings can have various forms, its normalization form is lowercase hex digits in standard form (e.g., 118fe23b-0380-4d15-8f2d-9f8c6f55e5a5).",
     "type": "fixture.types.uuid-list",
-    "input": {
-        "_type": "uuid_list",
-        "values": [
-            "118fe23b-0380-4d15-8f2d-9f8c6f55e5a5",
-            "118FE23B-0380-4D15-8F2D-9F8C6F55E5A5",
-            "118fe23b03804d158f2d-9f8c6f55e5a5",
-            "118FE23B03804D158F2D9F8C6F55E5A5"
-        ]
-    },
-    "normal": {
-        "_type": "uuid_list",
-        "values": [
-            "118fe23b-0380-4d15-8f2d-9f8c6f55e5a5",
-            "118fe23b-0380-4d15-8f2d-9f8c6f55e5a5",
-            "118fe23b-0380-4d15-8f2d-9f8c6f55e5a5",
-            "118fe23b-0380-4d15-8f2d-9f8c6f55e5a5"
-        ]
-    }
+    "input": [
+        "118fe23b-0380-4d15-8f2d-9f8c6f55e5a5",
+        "118FE23B-0380-4D15-8F2D-9F8C6F55E5A5",
+        "118fe23b03804d158f2d-9f8c6f55e5a5",
+        "118FE23B03804D158F2D9F8C6F55E5A5"
+    ],
+    "normal": [
+        "118fe23b-0380-4d15-8f2d-9f8c6f55e5a5",
+        "118fe23b-0380-4d15-8f2d-9f8c6f55e5a5",
+        "118fe23b-0380-4d15-8f2d-9f8c6f55e5a5",
+        "118fe23b-0380-4d15-8f2d-9f8c6f55e5a5"
+    ]
 }

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     six
     flake8
     pytest
+    py27: python-dateutil
 commands =
     pip install -f {distdir} -e {distdir}/nirum_fixture
     flake8 test/python


### PR DESCRIPTION
This patch basically deals with a part of #160, with several other changes related to it.

- It makes all generated Pyhon codes completely free from `validate_*()` runtime functions that *nirum-python* library provides.  See also added `Nirum.Targets.Python.Validators` module.
- Besides that, it also adds more validations like range/format checks, e.g., time zone awareness of a `datetime` value.
- Fixes #220.
- On Python 2, `uri` became represented as `basestring` instead of `unicode`, since URI (unlike IRI) is limited to a subset of ASCII character set.
- Cherry-picked two commits from #244.

See also *CHANGES.md*.