### PR TITLE
Make Docker image to have CA certificates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@ Version 0.3.3
 
 To be released.
 
+### Et cetera
+
+ -  The official Docker images became to have CA certificates.
+
 
 Version 0.3.2
 -------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ FROM alpine:3.7 AS build
 RUN apk add --no-cache \
         bash~4.4.19 \
         build-base~0.5 \
+        ca-certificates \
         curl~7.58.0 \
         ghc~8.0.2 \
         zlib-dev~1.2.11
@@ -33,7 +34,7 @@ RUN stack build --flag nirum:static --copy-bins
 
 FROM alpine:3.7
 
-RUN apk add --no-cache bash~4.4.19
+RUN apk add --no-cache bash~4.4.19 ca-certificates
 
 RUN mkdir -p /bin
 COPY --from=build /root/.local/bin/nirum /bin/


### PR DESCRIPTION
It's useful when you need networking inside an image.