### PR TITLE
targets.docs.title config to render <title>

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -111,6 +111,12 @@ To be released.
     union qux = bar (text a) | quux (text b);
     ~~~~~~~~
 
+### Docs target
+
+ -  A new required configuration `targets.docs.title` was added.
+    It's rendered in generated HTML documents' `<title>` element.
+    [[#253]]
+
 ### Python target
 
  -  Generated Python packages became to have two [entry points] (a feature
@@ -159,6 +165,7 @@ To be released.
 [#13]: https://github.com/spoqa/nirum/issues/13
 [#220]: https://github.com/spoqa/nirum/issues/220
 [#227]: https://github.com/spoqa/nirum/pull/227
+[#253]: https://github.com/spoqa/nirum/pull/253
 [entry points]: https://setuptools.readthedocs.io/en/latest/pkg_resources.html#entry-points
 [python2-numbers-integral]: https://docs.python.org/2/library/numbers.html#numbers.Integral
 [python2-basestring]: https://docs.python.org/2/library/functions.html#basestring

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -168,6 +168,7 @@ To be released.
 [#253]: https://github.com/spoqa/nirum/pull/253
 [entry points]: https://setuptools.readthedocs.io/en/latest/pkg_resources.html#entry-points
 [python2-numbers-integral]: https://docs.python.org/2/library/numbers.html#numbers.Integral
+[python2-int]: https://docs.python.org/2/library/functions.html#int
 [python2-basestring]: https://docs.python.org/2/library/functions.html#basestring
 [python2-unicode]: https://docs.python.org/2/library/functions.html#unicode
 [glibc]: https://www.gnu.org/software/libc/

--- a/docs/annotation.md
+++ b/docs/annotation.md
@@ -76,7 +76,7 @@ The following annotations are common among more than one target languages.
 For target-specific annotations, read each target's docs.
 
 
-### `@docs` (`docs`)
+### `@docs` (`docs`)                                                     {#docs}
 
 `@docs` annotations represent docs comments (`# ...`).  The following two
 examples are equivalent, and the former is internally transformed to the latter:
@@ -102,7 +102,7 @@ a time.
 :   A docs text.
 
 
-### `@error`
+### `@error`                                                            {#error}
 
 Many object-oriented languages (e.g., Java, Python) require exception classes
 to inherit a specific base class (e.g., `Exception`) to be thrown.

--- a/docs/target/docs.md
+++ b/docs/target/docs.md
@@ -1,0 +1,34 @@
+Docs target
+===========
+
+This target does not generate any program code files, but HTML pages (and
+some extra assets like CSS).  It generates a kind of API reference docs for
+the given Nirum package: type definitions, union tags, enum members,
+service methods, and so on.
+
+
+Docs comments
+-------------
+
+Nirum provide two kinds of comments.  One is an ordinary comment which starts
+with `//`, and other one is a docs comment which begins with `#`.  Docs target
+is only aware of the latter.
+
+Docs comments are, unlike ordinal comments, not allowed to any places, but only
+allowed to some specific places.
+
+Docs comments are actually a syntactic sugar of [`@docs`](../annotation.md#docs)
+annotation, hence allowed to be attached to only where annotations are allowed:
+declarations that have a name, e.g., types, fields, members, services, methods,
+parameters, modules.
+
+You can find *examples/shapes.nrm* to see examples of docs comments.
+
+
+Settings
+--------
+
+### `title` (required): Docs title
+
+It goes to `<title>` elements of generated HTML pages.  It's usually a name of
+the Nirum package.

--- a/examples/package.toml
+++ b/examples/package.toml
@@ -3,3 +3,6 @@ version = "0.3.0"
 [targets.python]
 name = "nirum-examples"
 minimum_runtime = "0.3.9"
+
+[targets.docs]
+title = "Nirum Examples"

--- a/package.yaml
+++ b/package.yaml
@@ -137,6 +137,7 @@ tests:
     - hspec
     - hspec-core
     - hspec-meta
+    - hxt >=9.3.1.16 && <9.4.0.0
     - nirum
     - process >=1.1 && <2
     - semigroups

--- a/test/Nirum/TestFixtures.hs
+++ b/test/Nirum/TestFixtures.hs
@@ -1,0 +1,22 @@
+module Nirum.TestFixtures (fixturePackage, scanFixturePackage) where
+
+import Control.Monad
+import Data.Either
+
+import System.FilePath
+
+import Nirum.Package
+import Nirum.Package.Metadata
+
+
+-- | Scan test/nirum_fixture/ package.
+scanFixturePackage :: Target t => IO (Either PackageError (Package t))
+scanFixturePackage = scanPackage $ "test" </> "nirum_fixture"
+
+-- | Unsafe version of 'scanFixturePackage'.
+fixturePackage :: Target t => IO (Package t)
+fixturePackage = do
+    result <- scanFixturePackage
+    when (isLeft result) $ fail ("result: " ++ show result)
+    let Right pkg = result
+    return pkg

--- a/test/nirum_fixture/package.toml
+++ b/test/nirum_fixture/package.toml
@@ -7,8 +7,10 @@ keywords = ["sample", "example", "nirum"]
 name = "nirum"
 email = "dev@nirum.org"
 
-[targets]
 [targets.python]
 name = "nirum_fixture"
 [targets.python.renames]
 "renames.test" = "renamed"
+
+[targets.docs]
+title = "Fixtures for Nirum tests"


### PR DESCRIPTION
In order to render a meaningful `<title>`, a new required configuration `targets.docs.title` was added.