### PR TITLE
Make enum members and union tags to reserve top-level type namespace

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,106 @@ To be released.
  -  Union tags became possible to have `default` keyword.  It's useful
     for migrating a record type to a union type.  [[#13], [#227]]
 
+ -  Enum members and union tags became disallowed to shadow an other type name
+    in a module.  It's because in some target languages we compile both types
+    and members/tags into objects that share the same namespace.  In Python,
+    both types and union tags are compiled into classes.
+
+    For example, the following definitions had been allowed, but now became
+    disallowed:
+
+    ~~~~~~~~ nirum
+    unboxed foo (text);
+    //      ^~~
+    enum bar = foo | baz;
+    //         ^~~
+    ~~~~~~~~
+
+    ~~~~~~~~ nirum
+    record foo (text a);
+    //     ^~~
+    union bar = foo (text b) | baz (text c);
+    //          ^~~
+    ~~~~~~~~
+
+    This rule is applied even between a member/tag and its belonging enum/union
+    type as well.  The following definitions are disallowed:
+
+    ~~~~~~~~ nirum
+    enum foo = foo | bar;
+         ^~~   ^~~
+    ~~~~~~~~
+
+    ~~~~~~~~ nirum
+    union bar = foo (text a) | bar (text b);
+          ^~~                  ^~~
+    ~~~~~~~~
+
+    If you already have used the same name for a type and a tag, you can avoid
+    breaking backward compatibility of serialization by specifying a different
+    behind name.  For example, if you've had a definition like:
+
+    ~~~~~~~~ nirum
+    enum foo = foo | bar;
+    //   ^~~   ^~~
+    ~~~~~~~~
+
+    It can be changed like the following:
+
+    ~~~~~~~~ nirum
+    enum foo = foo-renamed/foo | bar;
+    //         ^~~~~~~~~~~ ^~~
+    ~~~~~~~~
+
+ -  Enum members and union tags became disallowed to shadow other enum members
+    and union tags even if they belong to an other type.  It's because in some
+    target language we compile them into objects that share the same namespace,
+    regardless of their belonging type.
+
+    For example, the following definitions had been allowed, but now became
+    disallowed:
+
+    ~~~~~~~~ nirum
+    enum foo = bar | baz;
+    //         ^~~
+    enum qux = quux | bar;
+    //                ^~~
+    ~~~~~~~~
+
+    ~~~~~~~~ nirum
+    union foo = bar (text a) | baz (text b);
+    //          ^~~
+    enum qux = quux | bar;
+    //                ^~~
+    ~~~~~~~~
+
+    ~~~~~~~~ nirum
+    union foo = bar (text a) | baz (text b);
+    //                         ^~~
+    union qux = quux (text c) | baz (text d);
+    //                          ^~~
+    ~~~~~~~~
+
+    If you already have used the same name for members/tags of different
+    enum/union types, you can avoid breaking backward compatibility of
+    serialization by specifying a different behind name.
+    For example, if you've had a definition like:
+
+    ~~~~~~~~ nirum
+    enum foo = bar | baz;
+    //         ^~~
+    union qux = bar (text a) | quux (text b);
+    //          ^~~
+    ~~~~~~~~
+
+    It can be changed like the following:
+
+    ~~~~~~~~ nirum
+    enum foo = bar-renamed/bar | baz;
+    //         ^~~~~~~~~~~ ^~~
+    union qux = bar (text a) | quux (text b);
+    ~~~~~~~~
+
 ### Python target
 
  -  Generated Python packages became to have two [entry points] (a feature

--- a/src/Nirum/Constructs/Declaration.hs
+++ b/src/Nirum/Constructs/Declaration.hs
@@ -1,12 +1,15 @@
 {-# LANGUAGE DefaultSignatures #-}
-module Nirum.Constructs.Declaration ( Declaration (annotations, name)
+module Nirum.Constructs.Declaration ( Declaration (..)
                                     , Documented (docs, docsBlock)
                                     ) where
+
+import Data.Set (Set, empty)
 
 import Nirum.Constructs (Construct)
 import Nirum.Constructs.Annotation (AnnotationSet, lookupDocs)
 import Nirum.Constructs.Docs (Docs, toBlock)
-import Nirum.Constructs.Name (Name)
+import Nirum.Constructs.Identifier (Identifier)
+import Nirum.Constructs.Name (Name (..))
 import Nirum.Docs (Block)
 
 class Documented a where
@@ -19,7 +22,17 @@ class Documented a where
     docsBlock :: a -> Maybe Block
     docsBlock = fmap toBlock . docs
 
--- Construct which has its own unique 'name' and can has its 'docs'.
+-- | Construct which has its own unique 'name' and can has its 'docs'.
 class (Construct a, Documented a) => Declaration a where
     name :: a -> Name
     annotations :: a -> AnnotationSet
+
+    -- | A set of facial name identifiers that are public (or "exported")
+    -- but not used for name resolution.  (If an identifier should be a key
+    -- for resolution 'name' should return it.)
+    --
+    -- The default implementation simply returns an empty set.
+    --
+    -- Intended to be used for 'Nirum.Constructs.DeclarationSet.DeclarationSet'.
+    extraPublicNames :: a -> Set Identifier
+    extraPublicNames _ = empty

--- a/src/Nirum/Constructs/TypeDeclaration.hs
+++ b/src/Nirum/Constructs/TypeDeclaration.hs
@@ -61,17 +61,18 @@ import Data.Maybe (isJust, maybeToList)
 import Data.String (IsString (fromString))
 
 import qualified Data.Text as T
+import qualified Data.Set as S
 
 import Nirum.Constructs (Construct (toCode))
 import Nirum.Constructs.Annotation as A (AnnotationSet, empty, lookupDocs)
-import Nirum.Constructs.Declaration ( Declaration (annotations, name)
+import Nirum.Constructs.Declaration ( Declaration (..)
                                     , Documented (docs)
                                     )
 import Nirum.Constructs.Docs (Docs (Docs), toCodeWithPrefix)
 import Nirum.Constructs.DeclarationSet as DS
 import Nirum.Constructs.Identifier (Identifier)
 import Nirum.Constructs.ModulePath (ModulePath)
-import Nirum.Constructs.Name (Name (Name))
+import Nirum.Constructs.Name (Name (..))
 import Nirum.Constructs.Service ( Method
                                 , Service (Service)
                                 , methodDocs
@@ -298,6 +299,11 @@ instance Declaration TypeDeclaration where
     name TypeDeclaration { typename = name' } = name'
     name ServiceDeclaration { serviceName = name' } = name'
     name Import { importName = id' } = Name id' id'
+    extraPublicNames TypeDeclaration { type' = EnumType { members = ms } } =
+        S.fromList [facialName mName | EnumMember mName _ <- toList ms]
+    extraPublicNames TypeDeclaration { type' = unionType'@UnionType {} } =
+        S.fromList $ map (facialName . tagName) $ toList $ tags unionType'
+    extraPublicNames _ = S.empty
     annotations TypeDeclaration { typeAnnotations = anno' } = anno'
     annotations ServiceDeclaration { serviceAnnotations = anno' } = anno'
     annotations Import { importAnnotations = anno' } = anno'

--- a/test/nirum_fixture/fixture/foo.nrm
+++ b/test/nirum_fixture/fixture/foo.nrm
@@ -22,9 +22,6 @@ enum eva-char = soryu-asuka-langley
               | nagisa-kaworu
               ;
 
-enum reserved-keyword-enum = mro | no-mro;
-union reserved-keyword-union = mro | no-mro;
-
 record point1 (
     # Record docs.
     bigint left/x,

--- a/test/nirum_fixture/fixture/reserved-keyword-enum.nrm
+++ b/test/nirum_fixture/fixture/reserved-keyword-enum.nrm
@@ -1,0 +1,1 @@
+enum reserved-keyword-enum = mro | no-mro;

--- a/test/nirum_fixture/fixture/reserved-keyword-union.nrm
+++ b/test/nirum_fixture/fixture/reserved-keyword-union.nrm
@@ -1,0 +1,1 @@
+union reserved-keyword-union = mro | no-mro;

--- a/test/python/primitive_test.py
+++ b/test/python/primitive_test.py
@@ -9,16 +9,17 @@ from six import PY3
 from fixture.foo import (Album, CultureAgnosticName, Dog,
                          EastAsianName, EvaChar,
                          FloatUnbox, Gender, ImportedTypeUnbox, Irum,
-                         Line, MixedName, Mro, Music, NoMro,
+                         Line, MixedName, Music,
                          NameShadowingFieldRecord, NullService,
                          Person, People,
                          Point1, Point2, Point3d, Pop, PingService, Product,
                          RecordWithMap, RecordWithOptionalRecordField,
-                         ReservedKeywordEnum, ReservedKeywordUnion,
                          Rnb, RpcError, Run, Song, Status, Stop, Way,
                          WesternName)
 from fixture.foo.bar import PathUnbox, IntUnbox, Point
 from fixture.qux import Path, Name
+from fixture.reserved_keyword_enum import ReservedKeywordEnum
+from fixture.reserved_keyword_union import Mro, NoMro, ReservedKeywordUnion
 from fixture.types import UuidList
 
 

--- a/test/python/setup_test.py
+++ b/test/python/setup_test.py
@@ -21,6 +21,7 @@ def test_setup_metadata():
     assert ['nirum'] == pkg['Requires']
     assert set(pkg['Provides']) == {
         'fixture', 'fixture.foo', 'fixture.foo.bar', 'fixture.qux',
+        'fixture.reserved_keyword_enum', 'fixture.reserved_keyword_union',
         'fixture.types',
         'renamed', 'renamed.foo', 'renamed.foo.bar',
     }
@@ -33,6 +34,7 @@ def test_module_entry_points():
     map_ = pkg_resources.get_entry_map('nirum_fixture', group='nirum.modules')
     assert frozenset(map_) == {
         'fixture.foo', 'fixture.foo.bar', 'fixture.qux',
+        'fixture.reserved-keyword-enum', 'fixture.reserved-keyword-union',
         'fixture.types',
         'renames.test.foo', 'renames.test.foo.bar',
     }


### PR DESCRIPTION
In order to make Nirum IDL more portable to various target languages, I added some more rules to restrict name shadowing.  See also changelog I wrote.