### PR TITLE
Nicer error message on name duplicates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,6 +62,8 @@ To be released.
     //         ^~~~~~~~~~~ ^~~
     ~~~~~~~~
 
+    [[#254], [#255]]
+
  -  Enum members and union tags became disallowed to shadow other enum members
     and union tags even if they belong to an other type.  It's because in some
     target language we compile them into objects that share the same namespace,
@@ -111,6 +113,8 @@ To be released.
     union qux = bar (text a) | quux (text b);
     ~~~~~~~~
 
+    [[#254], [#255]]
+
 ### Python target
 
  -  Generated Python packages became to have two [entry points] (a feature
@@ -159,6 +163,8 @@ To be released.
 [#13]: https://github.com/spoqa/nirum/issues/13
 [#220]: https://github.com/spoqa/nirum/issues/220
 [#227]: https://github.com/spoqa/nirum/pull/227
+[#254]: https://github.com/spoqa/nirum/pull/254
+[#255]: https://github.com/spoqa/nirum/pull/255
 [entry points]: https://setuptools.readthedocs.io/en/latest/pkg_resources.html#entry-points
 [python2-numbers-integral]: https://docs.python.org/2/library/numbers.html#numbers.Integral
 [python2-basestring]: https://docs.python.org/2/library/functions.html#basestring


### PR DESCRIPTION
Continued from #254.  Now give nicer error message on name duplicates.  Offset line/column number became accurate.

Where the following Nirum code is given:

```nirum

union bar = foo
          | bar
          | baz;

```

Although the compiler had given the following error message (which refers to inaccurate offset line/column number):

```
examples/a.nrm:5:1:
the facial type name `bar` is duplicated


^
```

It's now like the following:

```
examples/a.nrm:3:13:
the tag name `bar` is duplicated

          | bar
            ^
```

See also the added `"handling name duplications"` test case.