### PR TITLE
Show table of contents in the docs sidebar

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -124,6 +124,8 @@ To be released.
     It's rendered in generated HTML documents' `<title>` element.
     [[#253]]
 
+ -  Docs now have a sidebar which contains table of contents.  [[#257]]
+
 ### Python target
 
  -  Generated Python packages became to have two [entry points] (a feature
@@ -175,6 +177,7 @@ To be released.
 [#253]: https://github.com/spoqa/nirum/pull/253
 [#254]: https://github.com/spoqa/nirum/pull/254
 [#255]: https://github.com/spoqa/nirum/pull/255
+[#257]: https://github.com/spoqa/nirum/pull/257
 [entry points]: https://setuptools.readthedocs.io/en/latest/pkg_resources.html#entry-points
 [python2-numbers-integral]: https://docs.python.org/2/library/numbers.html#numbers.Integral
 [python2-int]: https://docs.python.org/2/library/functions.html#int


### PR DESCRIPTION
Docs now have a sidebar and it shows the table of contents.

![An index page](https://user-images.githubusercontent.com/12431/38260194-eb653412-37a1-11e8-811b-c2116f8f44a4.png)

![A module page](https://user-images.githubusercontent.com/12431/38260208-f207a7c8-37a1-11e8-800a-d56a581979fd.png)
