### PR TITLE
Runtime free deserializers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ before_install:
     checkmate --help
     token_encoded='gJvdss03HpHm1tCqhziBezjVi8Y='
     token="$(echo $token_encoded | python -m base64 -d | xxd -pu)"
-    checkmate github-travis --token "$token"
+    checkmate github-travis --token "$token" || true
   fi
 - |
   if [[ "$TRAVIS_OS_NAME" = "osx" ]]

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
         - upx-ucl
         - shellcheck
         - netbase
+        - ca-certificates
+        - libgnutls30
 
 env:
 - PIP_MINVER=9.0.1 SETUPTOOLS_MINVER=36.6.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
         - shellcheck
         - netbase
         - ca-certificates
-        - libgnutls30
+        - libgnutls28
 
 env:
 - PIP_MINVER=9.0.1 SETUPTOOLS_MINVER=36.6.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
         - libgmp10
         - upx-ucl
         - shellcheck
+        - netbase
 
 env:
 - PIP_MINVER=9.0.1 SETUPTOOLS_MINVER=36.6.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ before_install:
   if [[ "$TRAVIS_OS_NAME" = "linux" ]]
   then
     curl -o "$HOME/.local/bin/checkmate" \
-         -L https://github.com/spoqa/checkmate/releases/download/0.3.2/checkmate-linux-x86_64
+         -L https://github.com/spoqa/checkmate/releases/download/0.3.3/checkmate-linux-x86_64
     chmod +x "$HOME/.local/bin/checkmate"
     checkmate --help
     token_encoded='gJvdss03HpHm1tCqhziBezjVi8Y='

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -158,6 +158,52 @@ To be released.
         classes.  Nirum type names are qualified and their leading module paths
         are also normalized (the same rule to `nirum.modules` applies here).
 
+ -  Generated deserializers became independent from *nirum-python* runtime
+    library.  [[#160], [#272]]
+
+     -  Error messages made during deserialization became more standardized.
+        Every error now consists of two fields: one represents a path to the
+        value having an error, and other one is a human-readable message.
+
+        For example, suppose there's types like:
+
+        ~~~~~~~~ nirum
+        record user (dob date);
+        record user-group ([user] users);
+        ~~~~~~~~
+
+        and the following payload for `user-group` type is given:
+
+        ~~~~~~~~ json
+        [
+          {"_type": "user", "dob": "2000-06-30"},
+          {"_type": "user", "dob": "2000-13-32"}
+        ]
+        ~~~~~~~~
+
+        An error is reported with a path like `[1].dob`.
+
+     -  Added an optional `on_error` callback parameter to generated
+        `__nirum_deserialize__()` methods.
+
+        It has to be a callable which has two parameters (and no return value).
+        An `on_error` callback is called every time any validation/parsing error
+        happens during deserialization, and it can be called multiple times
+        at a single call of `__nirum_deserialize__()`.
+
+        The callback function's first parameter takes a string referring
+        a path to the value having an error (e.g., `'.users[0].dob'`).
+        The second parameter takes an error message string (e.g.,
+        `'Expected a string of RFC 3339 date, but the date is invalid.'`).
+
+        When it's omitted or `None`, a `ValueError` is raised with a multiline
+        message that consists of all error messages made during deserialization,
+        as it has been.
+
+ -  Fixed a bug that record/union deserializers refuses payloads without
+    `"_type"` field.  It is only for humans and can be omitted according to
+    the [specification](./docs/serialization.md).
+
  -  All integral types (`int32`, `int64`, and `bigint`) became represented
     as [`numbers.Integral`][python2-numbers-integral] instead of
     [`int`][python2-int].
@@ -174,6 +220,15 @@ To be released.
     besides class checks: range checks for `int32`/`int64`, time zone
     (``tzinfo``) awareness check for `datetime`, and basic format check for
     `uri`.
+
+ -  Removed `__nirum_get_inner_type__()` class methods from generated unboxed
+    type classes.
+
+ -  Removed `__nirum_record_behind_name__` static fields and
+    `__nirum_field_types__()` class methods from generated record type classes.
+
+ -  Removed `__nirum_tag_names__`, `__nirum_union_behind_name__`, and
+    `__nirum_field_names__` static fields from generated union type classes.
 
  -  Fixed a bug that generated service methods hadn't checked its arguments
     before its transport sends a payload.  [[#220]]
@@ -207,6 +262,7 @@ To be released.
 [#259]: https://github.com/spoqa/nirum/pull/259
 [#267]: https://github.com/spoqa/nirum/pull/267
 [#269]: https://github.com/spoqa/nirum/pull/269
+[#272]: https://github.com/spoqa/nirum/pull/272
 [entry points]: https://setuptools.readthedocs.io/en/latest/pkg_resources.html#entry-points
 [python2-numbers-integral]: https://docs.python.org/2/library/numbers.html#numbers.Integral
 [python2-int]: https://docs.python.org/2/library/functions.html#int

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -14,7 +14,6 @@ module Nirum.Targets.Python
     , compileModule
     , compileTypeDeclaration
     , parseModulePath
-    , stringLiteral
     , toNamePair
     , unionInstallRequires
     ) where
@@ -23,7 +22,6 @@ import Control.Monad (forM)
 import qualified Data.List as L
 import Data.Maybe (catMaybes, fromMaybe)
 import GHC.Exts (IsList (toList))
-import Text.Printf (printf)
 
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Map.Strict as M
@@ -132,24 +130,6 @@ toEnumMemberName name'
 
 toNamePair :: Name -> T.Text
 toNamePair (Name f b) = [qq|('{toAttributeName f}', '{I.toSnakeCaseText b}')|]
-
-stringLiteral :: T.Text -> T.Text
-stringLiteral string =
-    open $ T.concatMap esc string `T.snoc` '"'
-  where
-    open :: T.Text -> T.Text
-    open = if T.any (> '\xff') string then T.append [qq|u"|] else T.cons '"'
-    esc :: Char -> T.Text
-    esc '"' = "\\\""
-    esc '\\' = "\\\\"
-    esc '\t' = "\\t"
-    esc '\n' = "\\n"
-    esc '\r' = "\\r"
-    esc c
-        | c >= '\x10000' = T.pack $ printf "\\U%08x" c
-        | c >= '\xff' = T.pack $ printf "\\u%04x" c
-        | c < ' ' || c >= '\x7f' = T.pack $ printf "\\x%02x" c
-        | otherwise = T.singleton c
 
 toIndentedCodes :: (a -> T.Text) -> [a] -> T.Text -> T.Text
 toIndentedCodes f traversable concatenator =

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -206,15 +206,6 @@ compileDocsComment indentSpace d =
         Nothing -> "\n"
         Just rst -> indent (indentSpace `T.append` "#: ") rst
 
-indent :: Code -> Code -> Code
-indent space =
-    T.intercalate "\n" . map indentLn . T.lines
-  where
-    indentLn :: Code -> Code
-    indentLn line
-      | T.null line = T.empty
-      | otherwise = space `T.append` line
-
 type ParameterName = Code
 type ParameterType = Code
 type ReturnType = Code

--- a/src/Nirum/Targets/Python/CodeGen.hs
+++ b/src/Nirum/Targets/Python/CodeGen.hs
@@ -9,6 +9,7 @@ module Nirum.Targets.Python.CodeGen
     , Python (..)
     , PythonVersion (..)
     , RenameMap
+    , collectionsAbc
     , empty
     , getPythonVersion
     , importBuiltins
@@ -245,6 +246,13 @@ mangleVar expr arbitrarySideName = Data.Text.concat
     , arbitrarySideName
     , "__"
     ]
+
+collectionsAbc :: CodeGen Code
+collectionsAbc = do
+    ver <- getPythonVersion
+    importStandardLibrary $ case ver of
+        Python2 -> "collections"
+        Python3 -> "collections.abc"
 
 -- | Indent the given code.  If there are empty lines these are not indented.
 indent :: ToMarkup m => Code -> m -> Code

--- a/src/Nirum/Targets/Python/CodeGen.hs
+++ b/src/Nirum/Targets/Python/CodeGen.hs
@@ -14,6 +14,7 @@ module Nirum.Targets.Python.CodeGen
     , importBuiltins
     , importStandardLibrary
     , importTypingForPython3
+    , indent
     , insertLocalImport
     , insertStandardImport
     , insertStandardImportA
@@ -44,6 +45,11 @@ import Data.Map.Strict hiding (empty, member, toAscList)
 import Data.SemVer hiding (Identifier)
 import Data.Set hiding (empty)
 import Data.Text hiding (empty)
+import qualified Data.Text
+import Data.Text.Lazy (toStrict)
+import qualified Data.Text.Lazy
+import Text.Blaze (ToMarkup (preEscapedToMarkup))
+import Text.Blaze.Renderer.Text (renderMarkup)
 import Text.Printf (printf)
 
 import qualified Nirum.CodeGen
@@ -239,6 +245,20 @@ mangleVar expr arbitrarySideName = Data.Text.concat
     , arbitrarySideName
     , "__"
     ]
+
+-- | Indent the given code.  If there are empty lines these are not indented.
+indent :: ToMarkup m => Code -> m -> Code
+indent space =
+    intercalate "\n"
+        . fmap indentLn
+        . Data.Text.Lazy.split (== '\n')
+        . renderMarkup
+        . preEscapedToMarkup
+  where
+    indentLn :: Data.Text.Lazy.Text -> Code
+    indentLn line
+      | Data.Text.Lazy.null line = Data.Text.empty
+      | otherwise = space `append` toStrict line
 
 stringLiteral :: Text -> Code
 stringLiteral string =

--- a/src/Nirum/Targets/Python/CodeGen.hs
+++ b/src/Nirum/Targets/Python/CodeGen.hs
@@ -36,6 +36,7 @@ module Nirum.Targets.Python.CodeGen
     , stringLiteral
     , toAttributeName
     , toAttributeName'
+    , toBehindSnakeCaseText
     , toClassName
     , toClassName'
     , toImportPath'
@@ -263,6 +264,9 @@ toAttributeName identifier =
 
 toAttributeName' :: Name -> Text
 toAttributeName' = toAttributeName . facialName
+
+toBehindSnakeCaseText :: Name -> Text
+toBehindSnakeCaseText = toSnakeCaseText . behindName
 
 mangleVar :: Code -> Text -> Code
 mangleVar expr arbitrarySideName = Data.Text.concat

--- a/src/Nirum/Targets/Python/Deserializers.hs
+++ b/src/Nirum/Targets/Python/Deserializers.hs
@@ -1,0 +1,655 @@
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE QuasiQuotes #-}
+module Nirum.Targets.Python.Deserializers
+    ( compileDeserializer
+    ) where
+
+import Text.Blaze (Markup)
+import Text.Heterocephalus (compileText)
+import Text.InterpolatedString.Perl6 (qq)
+
+import Nirum.Constructs.Identifier
+import Nirum.Constructs.ModulePath
+import Nirum.Constructs.TypeDeclaration
+import Nirum.Constructs.TypeExpression
+import Nirum.Package.Metadata
+import Nirum.Targets.Python.CodeGen
+import Nirum.Targets.Python.Validators
+import Nirum.TypeInstance.BoundModule
+
+-- | It takes these arguments:
+--
+--     1. a 'BoundModule Python' for the context,
+--     2. a 'TypeExpression' which determines how it interprets an input,
+--     3. a Python expression of an input,
+--     4. a Python expression to store an output, and
+--     5. a Python expression of a function, takes two arguments, to store a
+--        possible error.
+--
+-- It returns a Python code that deserializes an input.
+--
+-- A Python expressions of the third argument should be a target (lvalue)
+-- expression, and the last argument should be evaluated as a Python callable.
+--
+-- A generated Python can be more than an expression; it can
+-- consists of multiple statements.  Note that its indentation level is zero.
+--
+-- For example, if we have a deserializer named @d@ the following code:
+--
+-- @
+--     d "inputs['x']" "outputs['x']" "error"
+-- @
+--
+-- could return a string containing a Python code like the following:
+--
+-- @
+--     if isinstance(inputs['x'], str):
+--         try:
+--             outputs['x'] = int(inputs['x'])
+--         except ValueError:
+--             errors('', 'Expected a numeric string.')
+--     else:
+--         error('', 'Expected a string.')
+-- @
+compileDeserializer
+    :: BoundModule Python -- | The compilation context.
+    -> TypeExpression -- | Determines how it interprets an input.
+    -> Code -- | A Python expression of an input.
+    -> Code -- | A Python expression to store an output.
+    -> Code -- | A Python expression of a function to store a possible error.
+    -> CodeGen Markup -- | A Python code that deserializes an input.
+compileDeserializer mod' typeExpr vInput vOutput vError = do
+    let intermOutput = mangleVar vOutput "interm"
+    let intermError = mangleVar vError "interm"
+    deserializer <- compileDeserializer'
+        mod' typeExpr vInput [qq|$intermOutput['rv']|] intermError
+    Validator pred' valueValidators' <-
+        compileValidator mod' typeExpr [qq|$intermOutput['rv']|]
+    return [compileText|
+#{intermOutput} = {}
+def #{intermError}(err_field, err_msg):
+    #{intermError}.errored = True
+    #{vError}(err_field, err_msg)
+#{deserializer}
+if not getattr(#{intermError}, 'errored', False) and #{intermOutput}:
+    if not (#{pred'}):
+        (#{vError})(
+            '',
+            'A deserialized value is unexpected type: {0!r}.'.format(
+                #{intermOutput}['rv']
+            )
+        )
+%{ forall ValueValidator predCode errorMsg <- valueValidators' }
+    elif not (#{predCode}):
+        (#{vError})('', #{stringLiteral errorMsg})
+%{ endforall }
+    (#{vOutput}) = #{intermOutput}['rv']
+    |]
+
+compileDeserializer'
+    :: BoundModule Python -- | The compilation context.
+    -> TypeExpression -- | Determines how it interprets an input.
+    -> Code -- | A Python expression of an input.
+    -> Code -- | A Python expression to store an output.
+    -> Code -- | A Python expression of a function to store a possible error.
+    -> CodeGen Markup -- | A Python code that deserializes an input.
+
+compileDeserializer' mod' (OptionModifier typeExpr) vInput vOutput vError = do
+    deserializer <- compileDeserializer mod' typeExpr vInput vOutput vError
+    return [compileText|
+if (#{vInput}) is None:
+    (#{vOutput}) = None
+else:
+#{indent "    " deserializer}
+    |]
+
+compileDeserializer' mod' (SetModifier typeExpr) vInput vOutput vError = do
+    let elInput = mangleVar vInput "element"
+        elIndex = mangleVar vInput "index"
+        elOutput = mangleVar vOutput "element"
+        elError = mangleVar vError "element"
+        elErrorFlag = mangleVar vError "errored"
+    builtins <- importBuiltins
+    baseString <- baseStringClass
+    mAbc <- collectionsAbc
+    deserializer <- compileDeserializer mod' typeExpr elInput elOutput elError
+    return [compileText|
+if (#{builtins}.isinstance(#{vInput}, #{mAbc}.Sequence) and
+    not #{builtins}.isinstance(#{vInput}, #{baseString})):
+    (#{vOutput}) = #{builtins}.set()
+    #{elErrorFlag} = [False]
+    def #{elError}(err_field, err_msg):
+        #{elErrorFlag}[0] = True
+        #{vError}(
+            '[{0}]{1}'.format(#{elIndex}, err_field), err_msg
+        )
+    for #{elIndex}, #{elInput} in #{builtins}.enumerate(#{vInput}):
+        #{elErrorFlag}[0] = False
+#{indent "        " deserializer}
+        if not #{elErrorFlag}[0]:
+            (#{vOutput}).add(#{elOutput})
+    (#{vOutput}) = #{builtins}.frozenset(#{vOutput})
+else:
+    (#{vError})('', 'Expected an array.')
+    |]
+
+compileDeserializer' mod' (ListModifier typeExpr) vInput vOutput vError = do
+    let elInput = mangleVar vInput "elem"
+        elIndex = mangleVar vInput "idx"
+        elOutput = mangleVar vOutput "elem"
+        elError = mangleVar vError "elem"
+        elErrorFlag = mangleVar vError "flag"
+    builtins <- importBuiltins
+    mAbc <- collectionsAbc
+    baseString <- baseStringClass
+    insertThirdPartyImportsA [("nirum.datastructures", [("list_type", "List")])]
+    deserializer <- compileDeserializer mod' typeExpr elInput elOutput elError
+    return [compileText|
+if (#{builtins}.isinstance(#{vInput}, #{mAbc}.Sequence) and
+    not #{builtins}.isinstance(#{vInput}, #{baseString})):
+    (#{vOutput}) = []
+    #{elErrorFlag} = [False]
+    def #{elError}(err_field, err_msg):
+        #{elErrorFlag}[0] = True
+        #{vError}(
+            '[{0}]{1}'.format(#{elIndex}, err_field), err_msg
+        )
+    for #{elIndex}, #{elInput} in #{builtins}.enumerate(#{vInput}):
+        #{elErrorFlag}[0] = False
+#{indent "        " deserializer}
+        if not #{elErrorFlag}[0]:
+            (#{vOutput}).append(#{elOutput})
+    (#{vOutput}) = list_type(#{vOutput})
+else:
+    (#{vError})(('', 'Expected an array.'))
+    |]
+
+compileDeserializer' mod' (MapModifier keyTypeExpr valueTypeExpr)
+                     vInput vOutput vError = do
+    let pairInput = mangleVar vInput "pair"
+        pairIndex = mangleVar vInput "index"
+        pairErrored = mangleVar vInput "errored"
+        keyInput = mangleVar vInput "key"
+        keyOutput = mangleVar vOutput "key"
+        keyError = mangleVar vError "key"
+        valueInput = mangleVar vInput "value"
+        valueOutput = mangleVar vOutput "value"
+        valueError = mangleVar vError "value"
+    mAbc <- collectionsAbc
+    builtins <- importBuiltins
+    baseString <- baseStringClass
+    insertThirdPartyImportsA [("nirum.datastructures", [("map_type", "Map")])]
+    keyDeserializer <- compileDeserializer
+        mod' keyTypeExpr keyInput keyOutput keyError
+    valueDeserializer <- compileDeserializer
+        mod' valueTypeExpr valueInput valueOutput valueError
+    return [compileText|
+if (#{builtins}.isinstance(#{vInput}, #{mAbc}.Sequence) and
+    not #{builtins}.isinstance(#{vInput}, #{baseString})):
+    (#{vOutput}) = []
+    (#{keyError}) = lambda err_field, err_msg: #{vError}(
+        '[{0}].key{1}'.format(#{pairIndex}, err_field),
+        err_msg
+    )
+    (#{valueError}) = lambda err_field, err_msg: #{vError}(
+        '[{0}].value{1}'.format(#{pairIndex}, err_field),
+        err_msg
+    )
+    for #{pairIndex}, #{pairInput} in #{builtins}.enumerate(#{vInput}):
+        (#{pairErrored}) = False
+        if #{builtins}.isinstance(#{pairInput}, #{mAbc}.Mapping):
+            try:
+                (#{keyInput}) = #{pairInput}['key']
+            except KeyError:
+                (#{vError})(
+                    '[{0}].key'.format(#{pairIndex}), 'Expected to exist.'
+                )
+                (#{pairErrored}) = True
+            else:
+#{indent "                " keyDeserializer}
+            try:
+                (#{valueInput}) = #{pairInput}['value']
+            except KeyError:
+                (#{vError})(
+                    '[{0}].value'.format(#{pairIndex}), 'Expected to exist.'
+                )
+                (#{pairErrored}) = True
+            else:
+#{indent "                " valueDeserializer}
+            if not #{pairErrored}:
+                (#{vOutput}).append((#{keyOutput}, #{valueOutput}))
+        else:
+            (#{vError})(
+                '[{0}]'.format(#{pairIndex}),
+                'Expected an object which has the fields "key" and "value".'
+            )
+    (#{vOutput}) = map_type(#{vOutput})
+else:
+    (#{vError})('', 'Expected an array of objects.')
+    |]
+
+compileDeserializer' mod' (TypeIdentifier typeId) vInput vOutput vError = do
+    builtins <- importBuiltins
+    case lookupType typeId mod' of
+        Missing -> return [compileText|raise #{builtins}.RuntimeError(
+            "This must never happen; it is likely to be a Nirum compiler's bug."
+        )|]
+        Local (Alias t) -> compileDeserializer mod' t vInput vOutput vError
+        Imported modulePath' _ (Alias t) ->
+            case resolveBoundModule modulePath' (boundPackage mod') of
+                Nothing -> return [compileText|raise #{builtins}.RuntimeError(
+                    "This must never happen; "
+                    "it is likely to be a Nirum compiler's bug."
+                )|]
+                Just foundMod ->
+                    compileDeserializer foundMod t vInput vOutput vError
+        Local PrimitiveType { primitiveTypeIdentifier = p } ->
+            compilePrimitiveTypeDeserializer p vInput vOutput vError
+        Imported _ _ PrimitiveType { primitiveTypeIdentifier = p } ->
+            compilePrimitiveTypeDeserializer p vInput vOutput vError
+        Local EnumType {} -> deserializerCall Nothing typeId
+        Imported m srcTypeId EnumType {} -> deserializerCall (Just m) srcTypeId
+        Local RecordType {} -> deserializerCall Nothing typeId
+        Imported m srcTypId RecordType {} -> deserializerCall (Just m) srcTypId
+        Local UnboxedType {} -> deserializerCall Nothing typeId
+        Imported m srcTypId UnboxedType {} -> deserializerCall (Just m) srcTypId
+        Local UnionType {} -> deserializerCall Nothing typeId
+        Imported m srcTypeId UnionType {} -> deserializerCall (Just m) srcTypeId
+  where
+    target' :: Python
+    target' = packageTarget $ boundPackage mod'
+    deserializerCall :: Maybe ModulePath -> Identifier -> CodeGen Markup
+    deserializerCall m sourceTypeId = do
+        case m of
+            Just mp -> insertThirdPartyImportsA
+                [ ( toImportPath target' mp
+                  , [(toClassName typeId, toClassName sourceTypeId)]
+                  )
+                ]
+            Nothing -> return ()
+        return [compileText|
+#{vOutput} = #{toClassName typeId}.__nirum_deserialize__(
+    #{vInput},
+    on_error=(#{vError})
+)
+        |]
+
+compilePrimitiveTypeDeserializer :: PrimitiveTypeIdentifier
+                                 -> Code
+                                 -> Code
+                                 -> Code
+                                 -> CodeGen Markup
+
+compilePrimitiveTypeDeserializer Bigint vInput vOutput vError = do
+    builtins <- importBuiltins
+    baseInteger <- baseIntegerClass
+    baseString <- baseStringClass
+    return [compileText|
+if #{builtins}.isinstance(#{vInput}, #{baseString}):
+    try:
+        #{vOutput} = #{builtins}.int(#{vInput})
+    except ValueError:
+        #{vError}(
+            '',
+            'Expected a string of decimal digits, '
+            'but the string consists of other than decimal digits.'
+        )
+elif #{builtins}.isinstance(#{vInput}, #{baseInteger}):
+    #{vOutput} = #{vInput}
+else:
+    #{vError}(
+        '',
+        'Expected a string of decimal digits, '
+        'but the given value is not a string.'
+    )
+    |]
+
+compilePrimitiveTypeDeserializer Decimal vInput vOutput vError = do
+    builtins <- importBuiltins
+    decimal <- importStandardLibrary "decimal"
+    baseString <- baseStringClass
+    return [compileText|
+if #{builtins}.isinstance(#{vInput}, #{baseString}):
+    try:
+        #{vOutput} = #{decimal}.Decimal(#{vInput})
+    except #{builtins}.ValueError:
+        #{vError}(
+            '', 'Expected a numeric string, but the string is not numeric.'
+        )
+else:
+    #{vError}(
+        '', 'Expected a numeric string, but the given value is not a string.'
+    )
+    |]
+
+compilePrimitiveTypeDeserializer Int32 vInput vOutput vError = do
+    baseInteger <- baseIntegerClass
+    builtins <- importBuiltins
+    baseString <- baseStringClass
+    return [compileText|
+if #{builtins}.isinstance(#{vInput}, #{baseInteger}):
+    #{vOutput} = #{vInput}
+elif #{builtins}.isinstance(#{vInput}, #{builtins}.float):
+    #{vOutput} = #{builtins}.int(#{vInput})
+    if #{vOutput} != (#{vInput}):
+        #{vError}(
+            '',
+            'Expected an integral number, the given number is not integral.'
+        )
+elif #{builtins}.isinstance(#{vInput}, #{baseString}):
+    try:
+        #{vOutput} = #{builtins}.int(#{vInput})
+    except #{builtins}.ValueError:
+        #{vError}(
+            '', 'Expected an integral number or a string of decimal digits.'
+        )
+else:
+    #{vError}(
+        '',
+        'Expected an integral number, but the given value is not a number.'
+    )
+    |]
+
+compilePrimitiveTypeDeserializer Int64 vInput vOutput vError =
+    compilePrimitiveTypeDeserializer Int32 vInput vOutput vError
+
+compilePrimitiveTypeDeserializer Float32 vInput vOutput vError = do
+    builtins <- importBuiltins
+    baseString <- baseStringClass
+    baseInteger <- baseIntegerClass
+    return [compileText|
+if #{builtins}.isinstance(#{vInput}, #{builtins}.float):
+    #{vOutput} = #{vInput}
+elif (#{builtins}.isinstance(#{vInput}, #{baseString}) or
+      #{builtins}.isinstance(#{vInput}, #{baseInteger})):
+    try:
+        #{vOutput} = #{builtins}.int(#{vInput})
+    except #{builtins}.ValueError:
+        #{vError}(
+            '',
+            'Expected a floating-point number or its string representation.'
+        )
+else:
+    #{vError}(
+        '',
+        'Expected a floating-point number, '
+        'but the given value is not a number.'
+    )
+    |]
+
+compilePrimitiveTypeDeserializer Float64 vInput vOutput vError =
+    compilePrimitiveTypeDeserializer Float32 vInput vOutput vError
+
+compilePrimitiveTypeDeserializer Text vInput vOutput vError = do
+    builtins <- importBuiltins
+    pyVer <- getPythonVersion
+    case pyVer of
+        Python3 -> return [compileText|
+if #{builtins}.isinstance(#{vInput}, #{builtins}.str):
+    #{vOutput} = #{vInput}
+else:
+    #{vError}('', 'Expected a string.')
+        |]
+        Python2 -> return [compileText|
+if #{builtins}.isinstance(#{vInput}, #{builtins}.unicode):
+    #{vOutput} = #{vInput}
+elif #{builtins}.isinstance(#{vInput}, str):
+    try:
+        #{vOutput} = (#{vInput}).decode('utf-8')
+    except #{builtins}.UnicodeDecodeError:
+        try:
+            #{vOutput} = unicode(#{vInput})
+        except #{builtins}.UnicodeDecodeError:
+            #{vError}('', 'Expected a Unicode string.')
+else:
+    #{vError}('', 'Expected a string.')
+        |]
+
+compilePrimitiveTypeDeserializer Binary vInput vOutput vError = do
+    builtins <- importBuiltins
+    base64 <- importStandardLibrary "base64"
+    baseString <- baseStringClass
+    return [compileText|
+if #{builtins}.isinstance(#{vInput}, #{baseString}):
+    try:
+        #{vOutput} = #{base64}.b64decode(#{vInput})
+    except #{builtins}.ValueError:
+        #{vError}(
+            '',
+            'Expected a base64-encoded string, '
+            'but the string is not properly base64-encoded.'
+        )
+else:
+    #{vError}(
+        '',
+        'Expected a base64-encoded string, but the given value is not a string'
+    )
+    |]
+
+compilePrimitiveTypeDeserializer Date vInput vOutput vError = do
+    builtins <- importBuiltins
+    datetime <- importStandardLibrary "datetime"
+    re <- importStandardLibrary "re"
+    let vMatch = mangleVar vInput "match"
+    baseString <- baseStringClass
+    wrapScope vInput vOutput vError $ \ in' _ err -> return [compileText|
+if not #{builtins}.isinstance(#{in'}, #{baseString}):
+    #{err}(
+        '',
+        'Expected a string of RFC 3339 date, '
+        'but the given value is not a string.'
+    )
+#{vMatch} = #{re}.match(r'^(\d{4})-(\d\d)-(\d\d)$', #{in'})
+if not #{vMatch}:
+    #{err}(
+        '',
+        'Expected a string of RFC 3339 date, '
+        'but the string is not a valid RFC 3339 date format.'
+    )
+try:
+    return #{datetime}.date(
+        #{builtins}.int(#{vMatch}.group(1)),
+        #{builtins}.int(#{vMatch}.group(2)),
+        #{builtins}.int(#{vMatch}.group(3)),
+    )
+except #{builtins}.ValueError:
+    #{err}(
+        '',
+        'Expected a string of RFC 3339 date, but the date is invalid.'
+    )
+    |]
+
+compilePrimitiveTypeDeserializer Datetime vInput vOutput vError = do
+    builtins <- importBuiltins
+    datetime <- importStandardLibrary "datetime"
+    pyVer <- getPythonVersion
+    case pyVer of
+        Python3 -> do
+            re <- importStandardLibrary "re"
+            let vMatch = mangleVar vInput "match"
+                vTz = mangleVar vInput "tz"
+            wrapScope vInput vOutput vError $ \ in' _ err ->
+                return [compileText|
+if not #{builtins}.isinstance(#{in'}, #{builtins}.str):
+    #{err}(
+        '',
+        'Expected a string of RFC 3339 date & time, '
+        'but the given value is not a string.'
+    )
+#{vMatch} = #{re}.match(
+    r'^(\d{4})-(\d\d)-(\d\d)T(\d\d):(\d\d):(\d\d)'
+    r'(?:\.(\d*))?'
+    r'(Z|([+-])(\d\d):?(\d\d))$',
+    #{in'}
+)
+if not #{vMatch}:
+    #{err}(
+        '',
+        'Expected a string of RFC 3339 date & time, '
+        'but the string is not a valid RFC 3339 date & time format.'
+    )
+try:
+    if #{vMatch}.group(8) == 'Z':
+        #{vTz} = #{datetime}.timezone.utc
+    else:
+        #{vTz} = #{datetime}.timezone(
+            #{datetime}.timedelta(
+                hours=#{builtins}.int(#{vMatch}.group(10)),
+                minutes=#{builtins}.int(#{vMatch}.group(11))
+            )
+        )
+        if #{vMatch}.group(9) == '-':
+            #{vTz} = -#{vTz}
+    return #{datetime}.datetime(
+        #{builtins}.int(#{vMatch}.group(1)),
+        #{builtins}.int(#{vMatch}.group(2)),
+        #{builtins}.int(#{vMatch}.group(3)),
+        #{builtins}.int(#{vMatch}.group(4)),
+        #{builtins}.int(#{vMatch}.group(5)),
+        #{builtins}.int(#{vMatch}.group(6)),
+        #{builtins}.int((#{vMatch}.group(7) or '0')[:6].zfill(6)),
+        tzinfo=#{vTz}
+    )
+except #{builtins}.ValueError:
+    #{err}(
+        '',
+        'Expected a string of RFC 3339 date & time, '
+        'but the date & time is invalid.'
+    )
+                |]
+        Python2 -> do
+            addOptionalDependency (3, 0) "iso8601"
+            insertThirdPartyImportsA
+                [("iso8601", [("_parse_iso8601", "parse_date")])]
+            insertThirdPartyImportsA
+                [("iso8601.iso8601", [("_iso8601_parse_error", "ParseError")])]
+            let vException = mangleVar vError "exc"
+            wrapScope vInput vOutput vError $ \ in' _ err ->
+                return [compileText|
+if not #{builtins}.isinstance(#{in'}, #{builtins}.basestring):
+    #{err}(
+        '',
+        'Expected a string of RFC 3339 date & time, '
+        'but the given value is not a string.'
+    )
+try:
+    return _parse_iso8601(#{in'})
+except _iso8601_parse_error as #{vException}:
+    if #{builtins}.str(#{vException}).startswith('Unable to parse'):
+        #{err}(
+            '',
+            'Expected a string of RFC 3339 date & time, '
+            'but the string is not a valid RFC 3339 date & time format.'
+        )
+    else:
+        #{err}(
+            '',
+            'Expected a string of RFC 3339 date & time, '
+            'but the date & time is invalid.'
+        )
+                |]
+
+compilePrimitiveTypeDeserializer Bool vInput vOutput vError = do
+    builtins <- importBuiltins
+    return [compileText|
+if #{builtins}.isinstance(#{vInput}, #{builtins}.bool):
+    #{vOutput} = #{vInput}
+else:
+    #{vError}('', 'Expected a boolean value; true or false.')
+    |]
+
+compilePrimitiveTypeDeserializer Uuid vInput vOutput vError =
+    wrapScope vInput vOutput vError $ \ in' _ err -> do
+        builtins <- importBuiltins
+        uuid <- importStandardLibrary "uuid"
+        baseString <- baseStringClass
+        return [compileText|
+if not #{builtins}.isinstance(#{in'}, #{baseString}):
+    #{err}(
+        '', 'Expected a string of UUID, but the given value is not a string.'
+    )
+try:
+    return #{uuid}.UUID(#{in'})
+except #{builtins}.ValueError:
+    #{err}(
+        '',
+        'Expected a string of UUID, '
+        'but the string is not a valid hexadecimal UUID format.'
+    )
+        |]
+
+compilePrimitiveTypeDeserializer Uri vInput vOutput vError =
+    compilePrimitiveTypeDeserializer Text vInput vOutput vError
+
+-- | Wrap a Python deserializer code block into an isolated scope.
+--
+-- Without this function, a deserializer code cannot @return@ or @raise@,
+-- because it is embeded in the middle of other Python code which shares
+-- the flow.  It it controls its flow using @return@ or @raise@ the other
+-- code that embeds it also can be terminated together.
+--
+-- That means a deserializer code should not be like:
+--
+-- @
+--     if not condition_1:
+--         #{vError}('', 'It should satisfy the condition_1.')
+--     elif not condition_2:
+--         #{vError}('', 'It should satisfy the condition_2.')
+--     if mode:
+--         try:
+--             return result()
+--         except ValueError:
+--             #{vError}('', 'A value is invalid')
+--     return result2()
+-- @
+--
+-- but instead be:
+--
+-- @
+--     if condition_1:
+--         if not condition_2:
+--             if mode:
+--                 try:
+--                     #{vOutput} = result()
+--                 except ValueError:
+--                     #{vError}('', 'A value is invalid')
+--              else:
+--                  #{vOutput} = result2()
+--         else:
+--             #{vError}('', 'It should satisfy the condition_2.')
+--     else:
+--         #{vError}('', 'It should satisfy the condition_1.')
+-- @
+--
+-- which is too much indented and using assignig a result to the output
+-- variable instead of just returning it.  It is fragile and bug-prone since
+-- we can use @return@ or @raise@ by mistake.
+--
+-- The 'wrapScope' function offers an isolated flow, i.e., a function scope.
+-- With this, returning a value is equivalent to assigning it to the output
+-- variable, and raising an exception is calling an error function.
+wrapScope :: Code -> Code -> Code
+          -> (Code -> Code -> Code -> CodeGen Markup)
+          -> CodeGen Markup
+wrapScope vInput vOutput vError callback = do
+    let f = mangleVar vInput "scoped_func"
+    let exc = mangleVar vError "exc"
+    let scopedInput = mangleVar vInput "scoped"
+    let scopedOutput = mangleVar vOutput "scoped"
+    let scopedError = mangleVar vError "scoped"
+    builtins <- importBuiltins
+    scopedCode <- callback scopedInput scopedOutput scopedError
+    return [compileText|
+def #{f}(#{scopedInput}):
+    def #{scopedError}(err_field, err_msg):
+        raise ValueError(err_field, err_msg)
+    #{indent "    " scopedCode}
+    return #{scopedOutput}
+try:
+    #{vOutput} = #{f}(#{vInput})
+except #{builtins}.ValueError as #{exc}:
+    if #{builtins}.len(#{exc}.args) == 2:
+        #{vError}(*#{exc}.args)
+    else:
+        raise
+|]

--- a/src/Nirum/Targets/Python/Serializers.hs
+++ b/src/Nirum/Targets/Python/Serializers.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE QuasiQuotes #-}
 module Nirum.Targets.Python.Serializers (compileSerializer) where
 
-import Text.InterpolatedString.Perl6 (qq)
+import Data.Text (replace)
+import Text.InterpolatedString.Perl6 (q, qq)
 
 import Nirum.Constructs.TypeDeclaration
 import Nirum.Constructs.TypeExpression
@@ -70,7 +71,13 @@ compilePrimitiveTypeSerializer Text var = var
 compilePrimitiveTypeSerializer Binary var =
     [qq|__import__('base64').b64encode($var).decode('ascii')|]
 compilePrimitiveTypeSerializer Date var = [qq|($var).isoformat()|]
-compilePrimitiveTypeSerializer Datetime var = [qq|($var).isoformat()|]
+compilePrimitiveTypeSerializer Datetime var = replace "$var" var [q|(
+    '{0}-{1:02}-{2:02}T{3:02}:{4:02}:{5:02}'.format(
+        *($var).utctimetuple()
+    ) +
+    ('.{0:06}'.format(($var).microsecond) if ($var).microsecond else '') +
+    'Z'
+)|]
 compilePrimitiveTypeSerializer Bool var = var
 compilePrimitiveTypeSerializer Uuid var = [qq|str($var).lower()|]
 compilePrimitiveTypeSerializer Uri var = var

--- a/src/Nirum/Targets/Python/Validators.hs
+++ b/src/Nirum/Targets/Python/Validators.hs
@@ -113,13 +113,6 @@ compileInstanceValidator mod' typeId pythonVar = do
     cls <- compileTypeExpression mod' (Just (TypeIdentifier typeId))
     return $ Validator [qq|(isinstance(($pythonVar), ($cls)))|] []
 
-collectionsAbc :: CodeGen Code
-collectionsAbc = do
-    ver <- getPythonVersion
-    importStandardLibrary $ case ver of
-        Python2 -> "collections"
-        Python3 -> "collections.abc"
-
 multiplexValidators :: BoundModule Python
                     -> Code
                     -> [(TypeExpression, Code)]

--- a/test/Nirum/Targets/Python/CodeGenSpec.hs
+++ b/test/Nirum/Targets/Python/CodeGenSpec.hs
@@ -209,6 +209,27 @@ spec' = pythonVersionSpecs $ \ ver -> do
             let (abc, ctx) = runCodeGen collectionsAbc empty'
             abc `shouldBe` Right expectedModule
             standardImports ctx `shouldBe` [expected]
+        specify "baseStringClass" $ do
+            let (baseString, ctx) = runCodeGen baseStringClass empty'
+            case ver of
+                Python2 -> do
+                    baseString `shouldBe` Right "__builtin__.basestring"
+                    standardImports ctx `shouldBe`
+                        [("__builtin__", "__builtin__")]
+                Python3 -> do
+                    baseString `shouldBe` Right "__builtin__.str"
+                    standardImports ctx `shouldBe` [("__builtin__", "builtins")]
+        specify "baseIntegerClass" $ do
+            let (baseString, ctx) = runCodeGen baseIntegerClass empty'
+            case ver of
+                Python2 -> do
+                    baseString `shouldBe`
+                        Right "(__builtin__.int, __builtin__.long)"
+                    standardImports ctx `shouldBe`
+                        [("__builtin__", "__builtin__")]
+                Python3 -> do
+                    baseString `shouldBe` Right "__builtin__.int"
+                    standardImports ctx `shouldBe` [("__builtin__", "builtins")]
 
         let evalContext f = snd $ runCodeGen f empty'
         let req = empty'

--- a/test/Nirum/Targets/Python/CodeGenSpec.hs
+++ b/test/Nirum/Targets/Python/CodeGenSpec.hs
@@ -265,6 +265,12 @@ spec = do
         renameModulePath renames ["baz", "qux"] `shouldBe` ["p", "az", "qux"]
         renameModulePath renames ["qux", "foo"] `shouldBe` ["qux", "foo"]
 
+    specify "indent" $ do
+        indent "    " ("a\n    b\n\nc\n" :: Code) `shouldBe`
+            "    a\n        b\n\n    c\n"
+        indent "    " ("\"\"\"foo\nbar\n\"\"\"" :: Code) `shouldBe`
+            "    \"\"\"foo\n    bar\n    \"\"\""
+
     specify "stringLiteral" $ do
         stringLiteral "asdf" `shouldBe` [q|"asdf"|]
         stringLiteral [q|Say 'hello world'|]

--- a/test/Nirum/Targets/Python/CodeGenSpec.hs
+++ b/test/Nirum/Targets/Python/CodeGenSpec.hs
@@ -14,7 +14,7 @@ import Data.Maybe
 import Data.SemVer hiding (Identifier, metadata)
 import Test.Hspec.Meta
 import Text.Email.Validate (emailAddress)
-import Text.InterpolatedString.Perl6 (qq)
+import Text.InterpolatedString.Perl6 (q, qq)
 
 import Nirum.Constructs.Annotation (empty)
 import Nirum.Constructs.Identifier
@@ -264,3 +264,12 @@ spec = do
         renameModulePath renames ["baz"] `shouldBe` ["p", "az"]
         renameModulePath renames ["baz", "qux"] `shouldBe` ["p", "az", "qux"]
         renameModulePath renames ["qux", "foo"] `shouldBe` ["qux", "foo"]
+
+    specify "stringLiteral" $ do
+        stringLiteral "asdf" `shouldBe` [q|"asdf"|]
+        stringLiteral [q|Say 'hello world'|]
+            `shouldBe` [q|"Say 'hello world'"|]
+        stringLiteral [q|Say "hello world"|]
+            `shouldBe` [q|"Say \"hello world\""|]
+        stringLiteral "Say '\xc548\xb155'"
+            `shouldBe` [q|u"Say '\uc548\ub155'"|]

--- a/test/Nirum/Targets/Python/CodeGenSpec.hs
+++ b/test/Nirum/Targets/Python/CodeGenSpec.hs
@@ -202,6 +202,13 @@ spec' = pythonVersionSpecs $ \ ver -> do
             thirdPartyImports ctx2 `shouldBe` []
             localImports ctx2 `shouldBe` []
             compileError codeGen2 `shouldBe` Nothing
+        specify "collectionsAbc" $ do
+            let expected@(expectedModule, _) = case ver of
+                    Python2 -> ("_collections", "collections")
+                    Python3 -> ("_collections_abc", "collections.abc")
+            let (abc, ctx) = runCodeGen collectionsAbc empty'
+            abc `shouldBe` Right expectedModule
+            standardImports ctx `shouldBe` [expected]
 
 spec :: Spec
 spec = do

--- a/test/Nirum/Targets/PythonSpec.hs
+++ b/test/Nirum/Targets/PythonSpec.hs
@@ -1,11 +1,10 @@
-{-# LANGUAGE OverloadedLists, OverloadedStrings, QuasiQuotes,
-             ScopedTypeVariables #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module Nirum.Targets.PythonSpec where
 
 import qualified Data.Map.Strict as M
 import System.FilePath ((</>))
 import Test.Hspec.Meta
-import Text.InterpolatedString.Perl6 (q)
 
 import Nirum.Constructs.Module (Module (Module))
 import Nirum.Constructs.Name (Name (Name))
@@ -20,7 +19,6 @@ import Nirum.Targets.Python
     , addDependency
     , addOptionalDependency
     , parseModulePath
-    , stringLiteral
     , toNamePair
     , unionInstallRequires
     )
@@ -41,15 +39,6 @@ spec = do
             toNamePair "lambda" `shouldBe` "('lambda_', 'lambda')"
             toNamePair (Name "abc" "lambda") `shouldBe` "('abc', 'lambda')"
             toNamePair (Name "lambda" "abc") `shouldBe` "('lambda_', 'abc')"
-
-    specify "stringLiteral" $ do
-        stringLiteral "asdf" `shouldBe` [q|"asdf"|]
-        stringLiteral [q|Say 'hello world'|]
-            `shouldBe` [q|"Say 'hello world'"|]
-        stringLiteral [q|Say "hello world"|]
-            `shouldBe` [q|"Say \"hello world\""|]
-        stringLiteral "Say '\xc548\xb155'"
-            `shouldBe` [q|u"Say '\uc548\ub155'"|]
 
     describe "compilePackage" $ do
         it "returns a Map of file paths and their contents to generate" $ do

--- a/test/Nirum/Targets/PythonSpec.hs
+++ b/test/Nirum/Targets/PythonSpec.hs
@@ -11,16 +11,8 @@ import Nirum.Constructs.Name (Name (Name))
 import Nirum.Package.Metadata (Target (compilePackage))
 import Nirum.Targets.Python
     ( Source (Source)
-    , InstallRequires
-          ( InstallRequires
-          , dependencies
-          , optionalDependencies
-          )
-    , addDependency
-    , addOptionalDependency
     , parseModulePath
     , toNamePair
-    , unionInstallRequires
     )
 import Nirum.Targets.Python.CodeGenSpec hiding (spec)
 
@@ -101,50 +93,6 @@ spec = do
                     , "MANIFEST.in"
                     ]
             M.keysSet files' `shouldBe` directoryStructure'
-
-    describe "InstallRequires" $ do
-        let req = InstallRequires [] []
-            req2 = req { dependencies = ["six"] }
-            req3 = req { optionalDependencies = [((3, 4), ["enum34"])] }
-        specify "addDependency" $ do
-            addDependency req "six" `shouldBe` req2
-            addDependency req2 "six" `shouldBe` req2
-            addDependency req "nirum" `shouldBe`
-                req { dependencies = ["nirum"] }
-            addDependency req2 "nirum" `shouldBe`
-                req2 { dependencies = ["nirum", "six"] }
-        specify "addOptionalDependency" $ do
-            addOptionalDependency req (3, 4) "enum34" `shouldBe` req3
-            addOptionalDependency req3 (3, 4) "enum34" `shouldBe` req3
-            addOptionalDependency req (3, 4) "ipaddress" `shouldBe`
-                req { optionalDependencies = [((3, 4), ["ipaddress"])] }
-            addOptionalDependency req3 (3, 4) "ipaddress" `shouldBe`
-                req { optionalDependencies = [ ((3, 4), ["enum34", "ipaddress"])
-                                             ]
-                    }
-            addOptionalDependency req (3, 5) "typing" `shouldBe`
-                req { optionalDependencies = [((3, 5), ["typing"])] }
-            addOptionalDependency req3 (3, 5) "typing" `shouldBe`
-                req3 { optionalDependencies = [ ((3, 4), ["enum34"])
-                                              , ((3, 5), ["typing"])
-                                              ]
-                     }
-        specify "unionInstallRequires" $ do
-            (req `unionInstallRequires` req) `shouldBe` req
-            (req `unionInstallRequires` req2) `shouldBe` req2
-            (req2 `unionInstallRequires` req) `shouldBe` req2
-            (req `unionInstallRequires` req3) `shouldBe` req3
-            (req3 `unionInstallRequires` req) `shouldBe` req3
-            let req4 = req3 { dependencies = ["six"] }
-            (req2 `unionInstallRequires` req3) `shouldBe` req4
-            (req3 `unionInstallRequires` req2) `shouldBe` req4
-            let req5 = req { dependencies = ["nirum"]
-                           , optionalDependencies = [((3, 4), ["ipaddress"])]
-                           }
-                req6 = addOptionalDependency (addDependency req4 "nirum")
-                                             (3, 4) "ipaddress"
-            (req4 `unionInstallRequires` req5) `shouldBe` req6
-            (req5 `unionInstallRequires` req4) `shouldBe` req6
 
     specify "parseModulePath" $ do
         parseModulePath "" `shouldBe` Nothing

--- a/test/nirum_fixture/fixture/types.nrm
+++ b/test/nirum_fixture/fixture/types.nrm
@@ -1,7 +1,48 @@
 unboxed uuid-list ([uuid]);
 
+unboxed date-list ([date]);
+
+unboxed datetime-list ([datetime]);
+
 unboxed int32-unboxed (int32);
+
+unboxed uuid-unboxed (uuid);
 
 unboxed datetime-unboxed (datetime);
 
 unboxed float-unbox (float32);
+
+enum month
+    = january
+    | february
+    | march
+    | april
+    | may
+    | june
+    | july
+    | august
+    | september
+    | october
+    | november
+    | december
+    ;
+
+unboxed enum-unboxed (month);
+
+record product (
+    text name,
+    int32 stock,
+    decimal price-usd,
+);
+
+unboxed record-unboxed (product);
+
+union post
+    = image (text mime-type, binary data)
+    | link (uri link, text title, text? quote)
+    | article (text title, text content)
+    ;
+
+unboxed union-unboxed (post);
+
+unboxed unboxed-unboxed (record-unboxed);

--- a/test/python/docs_test.py
+++ b/test/python/docs_test.py
@@ -13,10 +13,12 @@ def test_record_docs():
 
        Record field docs\.
 
+
     .. attribute:: top'''
     assert Point2.__doc__.strip() == r'''.. attribute:: left
 
        Record field docs\.
+
 
     .. attribute:: top'''
     assert Point3d.__doc__.strip() == r'''.. attribute:: xy

--- a/test/python/primitive_test.py
+++ b/test/python/primitive_test.py
@@ -126,18 +126,18 @@ def test_record():
     point_serialized = {'_type': 'point1', 'x': 3, 'top': 14}
     assert point.__nirum_serialize__() == point_serialized
     assert Point1.__nirum_deserialize__(point_serialized) == point
-    with raises(ValueError):
-        Point1.__nirum_deserialize__({'x': 3, 'top': 14})
+    assert Point1.__nirum_deserialize__({'x': 3, 'top': 14}) == point
     with raises(ValueError):
         Point1.__nirum_deserialize__({'_type': 'foo'})
     with raises(ValueError) as e:
         Point1.__nirum_deserialize__({'_type': 'point1',
-                                      'left': 'a',
+                                      'x': 'a',
                                       'top': 'b'})
     assert str(e.value) == '''\
-left: invalid literal for int() with base 10: 'a'
-top: invalid literal for int() with base 10: 'b'\
-'''
+.top: Expected a string of decimal digits, but the string consists of other \
+than decimal digits.
+.x: Expected a string of decimal digits, but the string consists of other \
+than decimal digits.'''
     with raises(TypeError):
         Point1(left=1, top='a')
     with raises(TypeError):
@@ -162,8 +162,7 @@ top: invalid literal for int() with base 10: 'b'\
     point2_serialize = {'_type': 'point2', 'left': 3, 'top': 14}
     assert point2.__nirum_serialize__() == point2_serialize
     assert Point2.__nirum_deserialize__(point2_serialize) == point2
-    with raises(ValueError):  # no "_type" -- FIXME: "_type" is unnecessary
-        Point2.__nirum_deserialize__({'left': 3, 'top': 14})
+    assert Point2.__nirum_deserialize__({'left': 3, 'top': 14}) == point2
     with raises(ValueError):  # no "left" and "top" fields
         Point2.__nirum_deserialize__({'_type': 'foo'})
     p = Point2.__nirum_deserialize__({
@@ -320,8 +319,8 @@ def test_union():
             'given_name': 503,  # not a text
         })
     assert str(e.value) == '''\
-family_name: '404' is not a string.
-given_name: '503' is not a string.\
+.family_name: Expected a string.
+.given_name: Expected a string.\
 '''  # message can contain multiple errors
     n = MixedName.__nirum_deserialize__({  # invalid field types
         '_type': 'mixed_name',

--- a/test/python/renames_test.py
+++ b/test/python/renames_test.py
@@ -1,6 +1,0 @@
-from renamed.foo import FooTest
-from renamed.foo.bar import BarTest
-
-
-def test_imports_are_renamed():
-    assert FooTest.__nirum_field_types__()['a'] is BarTest

--- a/test/serialization/primitive-types/date-invalid-formats.json
+++ b/test/serialization/primitive-types/date-invalid-formats.json
@@ -1,0 +1,24 @@
+{
+    "description": "Date should be a valid RFC 3339 string of a proper date.",
+    "type": "fixture.types.date-list",
+    "input": [
+        "2018-05-10",
+        "2018-02-29",
+        "2018/02/29",
+        20180229
+    ],
+    "errors": [
+        {
+            "path": "[1]",
+            "message": "Expected a string of RFC 3339 date, but the date is invalid."
+        },
+        {
+            "path": "[2]",
+            "message": "Expected a string of RFC 3339 date, but the string is not a valid RFC 3339 date format."
+        },
+        {
+            "path": "[3]",
+            "message": "Expected a string of RFC 3339 date, but the given value is not a string."
+        }
+    ]
+}

--- a/test/serialization/primitive-types/datetime-invalid-formats.json
+++ b/test/serialization/primitive-types/datetime-invalid-formats.json
@@ -1,0 +1,25 @@
+{
+    "description": "Date & time should be a valid RFC 3339 string of a proper date & time.",
+    "type": "fixture.types.datetime-list",
+    "input": [
+        "2018-05-10T17:23:48.274498Z",
+        "2018-05-10T17:23:48Z",
+        "2018-02-29T00:00:00Z",
+        "2018/02/29",
+        20180229
+    ],
+    "errors": [
+        {
+            "path": "[2]",
+            "message": "Expected a string of RFC 3339 date & time, but the date & time is invalid."
+        },
+        {
+            "path": "[3]",
+            "message": "Expected a string of RFC 3339 date & time, but the string is not a valid RFC 3339 date & time format."
+        },
+        {
+            "path": "[4]",
+            "message": "Expected a string of RFC 3339 date & time, but the given value is not a string."
+        }
+    ]
+}

--- a/test/serialization/primitive-types/datetime.json
+++ b/test/serialization/primitive-types/datetime.json
@@ -1,0 +1,14 @@
+{
+    "description": "Whereas datetime deserializer should be able to consume several forms of RFC 3339 date & time, its serializers should produce only a limited form of RFC 3339 date & time.",
+    "type": "fixture.types.datetime-list",
+    "input": [
+        "2018-05-10T17:23:48.274498Z",
+        "2018-05-10T17:23:48.274498+00:00",
+        "2018-05-11T02:23:48.274498+09:00"
+    ],
+    "normal": [
+        "2018-05-10T17:23:48.274498Z",
+        "2018-05-10T17:23:48.274498Z",
+        "2018-05-10T17:23:48.274498Z"
+    ]
+}

--- a/test/serialization/primitive-types/uuid-hex.json
+++ b/test/serialization/primitive-types/uuid-hex.json
@@ -1,0 +1,19 @@
+{
+    "description": "UUID should be represented as a hexadecimal string.",
+    "type": "fixture.types.uuid-list",
+    "input": [
+        "118fe23b-0380-4d15-8f2d-9f8c6f55e5a5",
+        "23343962879229625363648903095734625701",
+        23343962879229625363648903095734625701
+    ],
+    "errors": [
+        {
+            "path": "[1]",
+            "message": "Expected a string of UUID, but the string is not a valid hexadecimal UUID format."
+        },
+        {
+            "path": "[2]",
+            "message": "Expected a string of UUID, but the given value is not a string."
+        }
+    ]
+}

--- a/test/serialization/records/missing-fields.json
+++ b/test/serialization/records/missing-fields.json
@@ -1,0 +1,17 @@
+{
+    "description": "Missing fields should make deserialization failed.",
+    "type": "fixture.foo.person",
+    "input": {
+        "_type": "person"
+    },
+    "errors": [
+        {
+            "path": ".first_name",
+            "message": "Expected to exist."
+        },
+        {
+            "path": ".last_name",
+            "message": "Expected to exist."
+        }
+    ]
+}

--- a/test/serialization/records/non-object.json
+++ b/test/serialization/records/non-object.json
@@ -1,0 +1,11 @@
+{
+    "description": "A record value must be represented as an object in JSON.",
+    "type": "fixture.foo.person",
+    "input": "invalid",
+    "errors": [
+        {
+            "path": "",
+            "message": "Expected an object."
+        }
+    ]
+}

--- a/test/serialization/unboxed-types/enum.json
+++ b/test/serialization/unboxed-types/enum.json
@@ -1,0 +1,6 @@
+{
+    "description": "If an unboxed type consists of an enum type it also has to be represented in the same way to its inner type.",
+    "type": "fixture.types.enum-unboxed",
+    "input": "may",
+    "normal": "may"
+}

--- a/test/serialization/unboxed-types/number.json
+++ b/test/serialization/unboxed-types/number.json
@@ -1,0 +1,6 @@
+{
+    "description": "If an unboxed type consists of a primitive type that is represented as a number in JSON it also has to be represented as a number in JSON.",
+    "type": "fixture.types.int32-unboxed",
+    "input": 1234,
+    "normal": 1234
+}

--- a/test/serialization/unboxed-types/record.json
+++ b/test/serialization/unboxed-types/record.json
@@ -1,0 +1,16 @@
+{
+    "description": "If an unboxed type consists of a record type it also has to be represented in the same way to its inner type.",
+    "type": "fixture.types.record-unboxed",
+    "input": {
+        "_type": "product",
+        "name": "White shirt",
+        "stock": 100,
+        "price_usd": "40.0"
+    },
+    "normal": {
+        "_type": "product",
+        "name": "White shirt",
+        "stock": 100,
+        "price_usd": "40.0"
+    }
+}

--- a/test/serialization/unboxed-types/string.json
+++ b/test/serialization/unboxed-types/string.json
@@ -1,0 +1,6 @@
+{
+    "description": "If an unboxed type consists of a primitive type that is represented as a string in JSON it also has to be represented as a string in JSON.",
+    "type": "fixture.types.uuid-unboxed",
+    "input": "850cd1a4-3c5e-4575-8c5f-fc41dab078a9",
+    "normal": "850cd1a4-3c5e-4575-8c5f-fc41dab078a9"
+}

--- a/test/serialization/unboxed-types/unboxed.json
+++ b/test/serialization/unboxed-types/unboxed.json
@@ -1,0 +1,16 @@
+{
+    "description": "If an unboxed type consists of an unboxed type again it also has to be represented in the same way to the inner type of its inner type.",
+    "type": "fixture.types.record-unboxed",
+    "input": {
+        "_type": "product",
+        "name": "White shirt",
+        "stock": 100,
+        "price_usd": "40.0"
+    },
+    "normal": {
+        "_type": "product",
+        "name": "White shirt",
+        "stock": 100,
+        "price_usd": "40.0"
+    }
+}

--- a/test/serialization/unboxed-types/union.json
+++ b/test/serialization/unboxed-types/union.json
@@ -1,0 +1,18 @@
+{
+    "description": "If an unboxed type consists of a record type it also has to be represented in the same way to its inner type.",
+    "type": "fixture.types.union-unboxed",
+    "input": {
+        "_type": "post",
+        "_tag": "link",
+        "link": "https://github.com/spoqa/nirum",
+        "title": "Nirum repository",
+        "quote": null
+    },
+    "normal": {
+        "_type": "post",
+        "_tag": "link",
+        "link": "https://github.com/spoqa/nirum",
+        "title": "Nirum repository",
+        "quote": null
+    }
+}

--- a/test/serialization/unions/missing-fields.json
+++ b/test/serialization/unions/missing-fields.json
@@ -1,0 +1,19 @@
+{
+    "description": "Missing fields should make deserialization failed.",
+    "type": "fixture.foo.mixed-name",
+    "input": {
+        "_type": "mixed_name",
+        "_tag": "western_name",
+        "middle_name": "H."
+    },
+    "errors": [
+        {
+            "path": ".first_name",
+            "message": "Expected to exist."
+        },
+        {
+            "path": ".last_name",
+            "message": "Expected to exist."
+        }
+    ]
+}

--- a/test/serialization/unions/missing-tag.json
+++ b/test/serialization/unions/missing-tag.json
@@ -1,0 +1,14 @@
+{
+    "description": "The \"_tag\" field is required unless there is a default tag.",
+    "type": "fixture.foo.music",
+    "input": {
+        "_type": "music",
+        "country": "South Korea"
+    },
+    "errors": [
+        {
+            "path": "._tag",
+            "message": "Expected to exist."
+        }
+    ]
+}

--- a/test/serialization/unions/non-object.json
+++ b/test/serialization/unions/non-object.json
@@ -1,0 +1,11 @@
+{
+    "description": "A union value must be represented as an object in JSON.",
+    "type": "fixture.foo.mixed-name",
+    "input": "invalid",
+    "errors": [
+        {
+            "path": "",
+            "message": "Expected an object."
+        }
+    ]
+}


### PR DESCRIPTION
This PR closes #160.

- Became to generate deserializer code instead of using `deserialize_meta()` function provided by *nirum-python* runtime library.
- In order to verify the correctness of generated deserializers, this PR adds several serialization test cases as well.
- Several common functions among serializers/deserializers/validators/etc were moved to `Nirum.Targets.Python.CodeGen` submodule.
- `InstallRequires` type and functions related to it are merged into `CodeGenContext`.

Please read added logs on *CHANGES.md* as well.