### PR TITLE
Add test suite based on examples of docs/serialization.md

### DIFF
--- a/test/nirum_fixture/fixture/foo.nrm
+++ b/test/nirum_fixture/fixture/foo.nrm
@@ -138,3 +138,7 @@ record name-shadowing-field-record (
     uuid uuid,
     binary bytes,
 );
+
+union optional-union = foo ( int32? bar )
+                     | baz ( int32 qux )
+                     ;

--- a/test/nirum_fixture/fixture/name.nrm
+++ b/test/nirum_fixture/fixture/name.nrm
@@ -1,0 +1,3 @@
+record foo (
+    int64 bar/baz,
+);

--- a/test/nirum_fixture/fixture/norm.nrm
+++ b/test/nirum_fixture/fixture/norm.nrm
@@ -1,0 +1,4 @@
+record Payload (
+    text FIELD_NAME,
+    float64 second-field-name,
+);

--- a/test/nirum_fixture/fixture/types.nrm
+++ b/test/nirum_fixture/fixture/types.nrm
@@ -29,6 +29,8 @@ enum month
 
 unboxed enum-unboxed (month);
 
+unboxed enum-set-unboxed ({month});
+
 record product (
     text name,
     int32 stock,
@@ -46,3 +48,5 @@ union post
 unboxed union-unboxed (post);
 
 unboxed unboxed-unboxed (record-unboxed);
+
+unboxed list-unboxed ([text]);

--- a/test/python/setup_test.py
+++ b/test/python/setup_test.py
@@ -25,6 +25,8 @@ def test_setup_metadata():
         'fixture.types', 'fixture.alias',
         'renamed', 'renamed.foo', 'renamed.foo.bar',
         'fixture.datetime',
+        'fixture.name',
+        'fixture.norm',
     }
     assert ['0.3.0'] == pkg['Version']
     assert ['Package description'] == pkg['Summary']
@@ -46,6 +48,8 @@ def test_module_entry_points():
         'fixture.alias',
         'renames.test.foo', 'renames.test.foo.bar',
         'fixture.datetime',
+        'fixture.name',
+        'fixture.norm',
     }
     import fixture.foo
     assert map_['fixture.foo'].resolve() is fixture.foo

--- a/test/serialization/enums/enums-female.json
+++ b/test/serialization/enums/enums-female.json
@@ -1,0 +1,6 @@
+{
+    "description": "enum",
+    "type": "fixture.foo.gender",
+    "input": "yeoseong",
+    "normal": "yeoseong"
+}

--- a/test/serialization/enums/enums-male.json
+++ b/test/serialization/enums/enums-male.json
@@ -1,0 +1,6 @@
+{
+    "description": "enum",
+    "type": "fixture.foo.gender",
+    "input": "male",
+    "normal": "male"
+}

--- a/test/serialization/identifiers/normalize.json.ignore
+++ b/test/serialization/identifiers/normalize.json.ignore
@@ -1,0 +1,15 @@
+FIXME: To follow a general principle of robustness, this test should be successful.
+{
+    "description": "All identifiers has to be normalized.",
+    "type": "fixture.norm.payload",
+    "input": {
+        "_type": "payload",
+        "FIELD_NAME": "FIELD_NAME becomes to field_name",
+        "second-field-name": 3.14
+    },
+    "normal": {
+        "_type": "payload",
+        "field_name": "FIELD_NAME becomes to field_name",
+        "second_field_name": 3.14
+    }
+}

--- a/test/serialization/map-types/record.json
+++ b/test/serialization/map-types/record.json
@@ -1,0 +1,21 @@
+{
+    "description": "Parse a map type.",
+    "type": "fixture.foo.record-with-map",
+    "input": {
+        "_type": "record_with_map",
+        "text_to_text": [
+            {"key": "a", "value": "foo"},
+            {"key": "b", "value": "bar"},
+            {"key": "c", "value": "baz"}
+        ]
+    },
+    "normal": {
+        "_type": "record_with_map",
+        "text_to_text": [
+            {"key": "a", "value": "foo"},
+            {"key": "b", "value": "bar"},
+            {"key": "c", "value": "baz"}
+        ]
+    },
+    "ignoreOrder": "$.text_to_text"
+}

--- a/test/serialization/names/behind_name.json
+++ b/test/serialization/names/behind_name.json
@@ -1,0 +1,12 @@
+{
+    "description": "Name can have behind name.",
+    "type": "fixture.name.foo",
+    "input": {
+        "_type": "foo",
+        "baz": 1
+    },
+    "normal": {
+        "_type": "foo",
+        "baz": 1
+    }
+}

--- a/test/serialization/primitive-types/date.json
+++ b/test/serialization/primitive-types/date.json
@@ -1,0 +1,10 @@
+{
+    "description": "Nirum date type is represented as RFC 3339 date in JSON.",
+    "type": "fixture.types.date-list",
+    "input": [
+        "2018-05-10"
+    ],
+    "normal": [
+        "2018-05-10"
+    ]
+}

--- a/test/serialization/records/emit-type.json
+++ b/test/serialization/records/emit-type.json
@@ -1,0 +1,13 @@
+{
+    "description": "_type can be emitted.",
+    "type": "fixture.foo.person",
+    "input": {
+        "first_name": "foo",
+        "last_name": "bar"
+    },
+    "normal": {
+        "_type": "person",
+        "first_name": "foo",
+        "last_name": "bar"
+    }
+}

--- a/test/serialization/records/extra-fields.json
+++ b/test/serialization/records/extra-fields.json
@@ -1,0 +1,15 @@
+{
+    "description": "Parse object has more fields than definition.",
+    "type": "fixture.foo.person",
+    "input": {
+        "_type": "person",
+        "first_name": "foo",
+        "last_name": "bar",
+        "extra": "some"
+    },
+    "normal": {
+        "_type": "person",
+        "first_name": "foo",
+        "last_name": "bar"
+    }
+}

--- a/test/serialization/records/option-fields.json
+++ b/test/serialization/records/option-fields.json
@@ -1,0 +1,11 @@
+{
+    "description": "If optional field isn't given, it should treat value of optional field is null.",
+    "type": "fixture.foo.record-with-optional-record-field",
+    "input": {
+        "_type": "record_with_optional_record_field"
+    },
+    "normal": {
+        "_type": "record_with_optional_record_field",
+        "f": null
+    }
+}

--- a/test/serialization/records/option-fields2.json
+++ b/test/serialization/records/option-fields2.json
@@ -1,0 +1,12 @@
+{
+    "description": "If a field is optional, it is ok to give null.",
+    "type": "fixture.foo.record-with-optional-record-field",
+    "input": {
+        "_type": "record_with_optional_record_field",
+        "f": null
+    },
+    "normal": {
+        "_type": "record_with_optional_record_field",
+        "f": null
+    }
+}

--- a/test/serialization/sets/record.json
+++ b/test/serialization/sets/record.json
@@ -1,0 +1,35 @@
+{
+    "description": "Parse a set of record.",
+    "type": "fixture.foo.people",
+    "input": {
+        "_type": "people",
+        "people": [
+            {
+                "_type": "person",
+                "first_name": "John",
+                "last_name": "Doe"
+            },
+            {
+                "_type": "person",
+                "first_name": "John",
+                "last_name": "Smith"
+            }
+        ]
+    },
+    "normal": {
+        "_type": "people",
+        "people": [
+            {
+                "_type": "person",
+                "first_name": "John",
+                "last_name": "Doe"
+            },
+            {
+                "_type": "person",
+                "first_name": "John",
+                "last_name": "Smith"
+            }
+        ]
+    },
+    "ignoreOrder": "$.people"
+}

--- a/test/serialization/unboxed-types/list.json
+++ b/test/serialization/unboxed-types/list.json
@@ -1,0 +1,6 @@
+{
+    "description": "If an unboxed type consists of a list type it also has to be represented in the same way to its inner type.",
+    "type": "fixture.types.list-unboxed",
+    "input": ["september", "april"],
+    "normal": ["september", "april"]
+}

--- a/test/serialization/unboxed-types/set.json
+++ b/test/serialization/unboxed-types/set.json
@@ -1,0 +1,7 @@
+{
+    "description": "If an unboxed type consists of a set type it also has to be represented in the same way to its inner type.",
+    "type": "fixture.types.enum-set-unboxed",
+    "input": ["february", "september"],
+    "normal": ["february", "september"],
+    "ignoreOrder": "$"
+}

--- a/test/serialization/unions/optional-field.json
+++ b/test/serialization/unions/optional-field.json
@@ -1,0 +1,13 @@
+{
+    "description": "If optional field isn't given, it should treat value of optional field is null.",
+    "type": "fixture.foo.optional-union",
+    "input": {
+        "_tag": "foo",
+        "_type": "optional_union"
+    },
+    "normal": {
+        "_tag": "foo",
+        "_type": "optional_union",
+        "bar": null
+    }
+}

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ skip_install = true
 deps =
     six
     flake8
+    jsonpath-ng
     pytest
     py27: python-dateutil
 commands =


### PR DESCRIPTION
- Added test suite based on examples of `docs/serialization.md`
- Added `ignoreOrder` option on test suit to test a `set` type or `map` type. Since there are no set-like types in JSON.
   - An indicator of the field in `ignoreOrder` has to be [jsonpath][]. It uses [jsonpath-ng][] on Python.
- More test suit has to be added followed pull request. Since there are huge changes of the python deserializer in https://github.com/spoqa/nirum/pull/272.

@dahlia Could you review this PR?

[jsonpath]: http://jsonpath.com/
[jsonpath-ng]: https://pypi.org/project/jsonpath-ng/

