### PR TITLE
Use Markup for Python CompileResult

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -230,6 +230,9 @@ To be released.
  -  Removed `__nirum_tag_names__`, `__nirum_union_behind_name__`, and
     `__nirum_field_names__` static fields from generated union type classes.
 
+ -  Removed `__nirum_schema_version__` static field from generated service
+    classes.
+
  -  Fixed a bug that generated service methods hadn't checked its arguments
     before its transport sends a payload.  [[#220]]
 

--- a/test/Nirum/Targets/PythonSpec.hs
+++ b/test/Nirum/Targets/PythonSpec.hs
@@ -7,31 +7,15 @@ import System.FilePath ((</>))
 import Test.Hspec.Meta
 
 import Nirum.Constructs.Module (Module (Module))
-import Nirum.Constructs.Name (Name (Name))
 import Nirum.Package.Metadata (Target (compilePackage))
 import Nirum.Targets.Python
     ( Source (Source)
     , parseModulePath
-    , toNamePair
     )
 import Nirum.Targets.Python.CodeGenSpec hiding (spec)
 
 spec :: Spec
 spec = do
-    describe "toNamePair" $ do
-        it "transforms the name to a Python code string of facial/behind pair" $
-            do toNamePair "text" `shouldBe` "('text', 'text')"
-               toNamePair (Name "test" "hello") `shouldBe` "('test', 'hello')"
-        it "replaces hyphens to underscores" $ do
-            toNamePair "hello-world" `shouldBe` "('hello_world', 'hello_world')"
-            toNamePair (Name "hello-world" "annyeong-sesang") `shouldBe`
-                "('hello_world', 'annyeong_sesang')"
-        it "appends an underscore if the facial name is a Python keyword" $ do
-            toNamePair "def" `shouldBe` "('def_', 'def')"
-            toNamePair "lambda" `shouldBe` "('lambda_', 'lambda')"
-            toNamePair (Name "abc" "lambda") `shouldBe` "('abc', 'lambda')"
-            toNamePair (Name "lambda" "abc") `shouldBe` "('lambda_', 'abc')"
-
     describe "compilePackage" $ do
         it "returns a Map of file paths and their contents to generate" $ do
             let (Source pkg _) = makeDummySource $ Module [] Nothing

--- a/test/python/docs_test.py
+++ b/test/python/docs_test.py
@@ -47,5 +47,6 @@ def test_service_docs():
     assert PingService.__doc__.strip() == r'Service docs\.'
     assert PingService.ping.__doc__.strip() == r'''Method docs\.
 
-        :param nonce: Parameter docs\.'''
+        :param nonce: (:class:`{class_}`)
+                      Parameter docs\.'''.format(class_=type(u'').__name__)
     assert NullService.__doc__ is None

--- a/test/python/primitive_test.py
+++ b/test/python/primitive_test.py
@@ -365,8 +365,6 @@ def test_union_tags_optional_initializer():
 def test_service():
     assert issubclass(NullService, Service)
     assert issubclass(PingService, Service)
-    assert getattr(PingService, '__nirum_schema_version__') == '0.3.0'
-    assert getattr(NullService, '__nirum_schema_version__') == '0.3.0'
     if PY3:
         import typing
         annots = typing.get_type_hints(PingService.ping)


### PR DESCRIPTION
- Became to use [`Text.Blaze.Markup`][1] type instead of [`Data.Text.Text`][2] type for `CompileResult Python`.  Duplicated `toStrict $ renderText $ ...` things were gone.
- Became to use Heterocephalus templating instead of Perl-style `qq` quasiquoter to render Python classes for service types.
- The metadata field `__nirum_schema_version__` was also gone as it has never been used.

[1]: https://www.stackage.org/haddock/lts-10.7/blaze-markup-0.8.2.0/Text-Blaze.html#t:Markup
[2]: https://www.stackage.org/haddock/lts-10.7/text-1.2.2.2/Data-Text.html#t:Text