### PR TITLE
minideb:jessie image lacks netbase

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,16 @@ Version 0.4.1
 To be released.
 
 
+### Et cetera
+
+ -  The official Docker images became to have netbase pacakage. See the
+    related issue([commercialhaskell/stack#2372][stack-issue-2372]) on stack
+    as well.
+
+
+[stack-issue-2732]: https://github.com/commercialhaskell/stack/issues/2372
+
+
 Version 0.4.0
 -------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN if [ "${APT_REPOSITORY}" != "" ]; then \
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
             build-essential ca-certificates curl \
+            netbase \
     && \
     rm -rf /var/lib/apt/lists/*
 RUN apt-get update && \


### PR DESCRIPTION
Building the docker image is failing with an error message ("(ConnectionFailure Network.BSD.getProtocolByName: does not exist (no such protocol name: tcp))"). I think the reason why the build is failing is that `minideb:jessie` which is the base image of nirum lacks the netbase package.

So I install it on Dockerfile.

See also, below links.

- https://github.com/dahlia/nirum/commit/c20d20653740336ce1fecb6b82b69d8bd4eb0c89
- https://github.com/commercialhaskell/stack/issues/2372#issuecomment-234113085