### PR TITLE
Upgrade to Stackage LTS Haskell 11.15

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -58,6 +58,13 @@
     - Nirum.Targets.Python.CodeGenSpec
 - ignore: {name: Unnecessary hiding}
 
+# Hlint seems unaware of variables in quasi-quotes.
+# See also: https://github.com/ndmitchell/hlint/issues/506
+- ignore:
+    name: Use const
+    within:
+    - Nirum.Targets.Python
+
 
 # Define some custom infix operators
 # - fixity: infixr 3 ~^#^~

--- a/package.yaml
+++ b/package.yaml
@@ -53,7 +53,7 @@ dependencies:
 - filepath >=1.4 && <1.5
 - htoml >=1.0.0.0 && <1.1.0.0
 - interpolatedstring-perl6 >=1.0.0 && <1.1.0
-- megaparsec >=6.3 && <6.4
+- megaparsec >=6.4 && <6.5
 - mtl >=2.2.1 && <3
 - parsec  # only for dealing with htoml's ParserError
 - pretty >=1.1.3 && <2
@@ -121,7 +121,7 @@ tests:
   hlint:
     main: lint.hs
     dependencies:
-    - hlint >=2.0.9 && <2.1
+    - hlint >=2.1.6 && <2.2
   spec:
     main: Main.hs
     source-dirs:

--- a/src/Nirum/Cli.hs
+++ b/src/Nirum/Cli.hs
@@ -10,7 +10,7 @@ import qualified Data.ByteString as B
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import qualified Data.Text as T
-import Control.Concurrent.STM (atomically, newTVar, readTVar, TVar, writeTVar)
+import Control.Concurrent.STM
 import Data.Monoid ((<>))
 import qualified Options.Applicative as OPT
 import System.Directory (createDirectoryIfMissing)
@@ -198,12 +198,12 @@ reactiveBuild :: AppOptions -> IO ()
 reactiveBuild options@AppOptions { building = building'
                                  , changed = changed'
                                  } = do
-    changed'' <- atomically $ readTVar changed'
+    changed'' <- readTVarIO changed'
     when changed'' $ do
         atomically $ writeTVar changed' False
         build options
         atomically $ writeTVar building' False
-        changedDuringBuild <- atomically $ readTVar changed'
+        changedDuringBuild <- readTVarIO changed'
         when changedDuringBuild $ reactiveBuild options
 
 tryDie :: AppOptions -> String -> IO ()

--- a/src/Nirum/Parser.hs
+++ b/src/Nirum/Parser.hs
@@ -184,9 +184,8 @@ annotationArgumentValue = do
         Just _ -> do
             v <- manyTill charLiteral (char '"')
             return $ AI.Text $ T.pack v
-        Nothing -> do
-            v <- integer
-            return $ Integer v
+        Nothing ->
+            Integer <$> integer
 
 annotationArgument :: Parser (Identifier, AnnotationArgument)
 annotationArgument = do

--- a/src/Nirum/Targets/Docs.hs
+++ b/src/Nirum/Targets/Docs.hs
@@ -155,7 +155,7 @@ $case expr'
 
 module' :: BoundModule Docs -> Html
 module' docsModule =
-    layout pkg depth (ModulePage docsModulePath) title $ [shamlet|
+    layout pkg depth (ModulePage docsModulePath) title [shamlet|
 $maybe tit <- headingTitle
     <h1>
         <dfn><code>#{path}</code>

--- a/src/Nirum/Targets/Python.hs
+++ b/src/Nirum/Targets/Python.hs
@@ -445,7 +445,7 @@ compileUnionTag source parentname d@(Tag typename' fields' _) = do
         fields'
     pyVer <- getPythonVersion
     defaultErrorHandler <- defaultDeserializerErrorHandler
-    return $ [compileText|
+    return [compileText|
 class #{className}(#{parentClass}):
 #{compileDocstringWithFields "    " d (map fcField fieldCodes)}
     __slots__ = (
@@ -1483,7 +1483,7 @@ compileModuleBody :: Source -> CodeGen Markup
 compileModuleBody src@Source { sourceModule = boundModule } = do
     let types' = boundTypes boundModule
     typeCodes <- mapM (compileTypeDeclaration src) $ toList types'
-    return $ [compileText|
+    return [compileText|
 %{forall typeCode <- typeCodes}
 #{typeCode}
 %{endforall}
@@ -1511,7 +1511,7 @@ compileModule pythonVersion' source = do
                       M.assocs (thirdPartyImports context)
     let globalDefs = globalDefinitions context
     code <- result
-    return $ (deps, optDeps,) $
+    return $ (deps, optDeps,)
         [compileText|# -*- coding: utf-8 -*-
 #{compileDocstring "" $ sourceModule source}
 %{ forall (alias, import') <- M.assocs (standardImports context) }

--- a/src/Nirum/Targets/Python/CodeGen.hs
+++ b/src/Nirum/Targets/Python/CodeGen.hs
@@ -216,7 +216,7 @@ addOptionalDependency pyVer package =
         pyVer
 
 getPythonVersion :: CodeGen PythonVersion
-getPythonVersion = fmap pythonVersion Control.Monad.State.get
+getPythonVersion = Control.Monad.State.gets pythonVersion
 
 renameModulePath :: RenameMap -> ModulePath -> ModulePath
 renameModulePath renameMap path' =

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,11 +1,8 @@
-resolver: lts-10.7
+resolver: lts-11.15
 flags: {}
 packages:
 - '.'
 extra-deps:
-- turtle-1.5.4
-  # Until turtle-1.5.0 it requires Win32<2.4 while unix-compat-0.5.0.1 (which
-  # is the version pinned by the Stackage LTS 10.7) requires Win32>=2.5.0.0.
 - uri-0.1.6.4
   # No in the Stackage LTS 10.7
 ## INSERT CODECOV HERE -- DO NOT REMOVE THIS COMMENT. SEE ALSO ISSUE #156. ##


### PR DESCRIPTION
- Since *turtle-1.5.9* is included to `lts-11.15`, remove *turtle-1.5.4* from `extra-deps`.  (See also the removed comment above it.)
- *hlint* is also upgraded to 2.1.6, and it introduces more suggestions (and a bug).  The most of changes are due to this, and an ignore is also added in order to work around *hlint*'s bug.  See the issue linked in a comment.