### PR TITLE
Upgrade to Stackage LTS Haskell 12.0

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -58,13 +58,6 @@
     - Nirum.Targets.Python.CodeGenSpec
 - ignore: {name: Unnecessary hiding}
 
-# Hlint seems unaware of variables in quasi-quotes.
-# See also: https://github.com/ndmitchell/hlint/issues/506
-- ignore:
-    name: Use const
-    within:
-    - Nirum.Targets.Python
-
 
 # Define some custom infix operators
 # - fixity: infixr 3 ~^#^~

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,10 @@ To be released.
     [[#126], [#281] by Jonghun Park]
  -  [CommonMark] in docstrings became to support [table syntax extension].
 
+### Et cetera
+
+ -  Dropped 32-bit Windows support.
+
 [#126]: https://github.com/spoqa/nirum/issues/126
 [#281]: https://github.com/spoqa/nirum/pull/281
 [CommonMark]: http://commonmark.org/

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Windows.  We provide the prebuilt executable binaries for these three platforms.
 ### Released builds
 
 You can download executable binaries for Linux (x86_64), macOS (x86_64), or
-Windows (x64 or x86) from the [latest release note][latest-release].
+Windows (x64) from the [latest release note][latest-release].
 You should give it appropriate permissions (e.g., `+x`) depending on your
 platform.
 
@@ -72,7 +72,6 @@ its bleeding edge.  We provide nightly builds for this purpose.
 - [Linux (x86_64)](https://nightly-builds.nirum.org/travis-builds/nirum-linux-x86_64)
 - [macOS (x86_64)](https://nightly-builds.nirum.org/travis-builds/nirum-darwin-x86_64)
 - [Windows (x64)](https://ci.appveyor.com/api/projects/dahlia/nirum-k5n5y/artifacts/nirum-win-x64.exe?job=Platform%3A%20x64&branch=master)
-- [Windows (x86)](https://ci.appveyor.com/api/projects/dahlia/nirum-k5n5y/artifacts/nirum-win-x86.exe?job=Platform%3A%20x86&branch=master)
 - [Docker (`spoqa/nirum:latest`)][docker]
 
 Although we call it "nightly build," technically it is not built every night,

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 version: "{build}"
 platform:
 - x64
-- x86
 environment:
   STACK_ROOT: C:\sr
   TOX: C:\Python36\Scripts\tox.exe
@@ -21,12 +20,7 @@ install:
 - ps: $env:PATH = 'C:\upx394w;' + $env:PATH;
 - ps: >
     if((Test-Path $env:STACK_ROOT) -ne $true) {
-      if($env:PLATFORM -eq 'x86') {
-        $stackUrl = 'https://github.com/commercialhaskell/stack/releases/download/v1.6.5/stack-1.6.5-windows-i386.zip';
-      }
-      elseif($env:PLATFORM -eq 'x64') {
-        $stackUrl = 'https://github.com/commercialhaskell/stack/releases/download/v1.6.5/stack-1.6.5-windows-x86_64.zip';
-      }
+      $stackUrl = 'https://github.com/commercialhaskell/stack/releases/download/v1.6.5/stack-1.6.5-windows-x86_64.zip';
       Invoke-WebRequest -OutFile C:\stack.zip $stackUrl;
       Add-Type -AssemblyName System.IO.Compression.FileSystem;
       [System.IO.Compression.ZipFile]::ExtractToDirectory('C:\stack.zip', $env:STACK_ROOT);
@@ -62,7 +56,6 @@ after_build:
 test_script:
 - stack --no-terminal test --jobs 1
 artifacts:
-- path: nirum-win-x86.exe
 - path: nirum-win-x64.exe
 deploy:
   provider: GitHub

--- a/package.yaml
+++ b/package.yaml
@@ -53,7 +53,7 @@ dependencies:
 - filepath >=1.4 && <1.5
 - htoml >=1.0.0.0 && <1.1.0.0
 - interpolatedstring-perl6 >=1.0.0 && <1.1.0
-- megaparsec >=6.4 && <6.5
+- megaparsec >=6.5 && <6.6
 - mtl >=2.2.1 && <3
 - parsec  # only for dealing with htoml's ParserError
 - pretty >=1.1.3 && <2
@@ -71,7 +71,7 @@ library:
   dependencies:
   - blaze-markup >=0.8.0.0 && <0.9
   - cmark-gfm >=0.1.3 && <0.2
-  - fsnotify >=0.2.1 && <0.3.0
+  - fsnotify >=0.3.0.1 && <0.4.0.0
   - heterocephalus >=1.0.5 && <1.1.0
   - optparse-applicative >=0.14 && <0.15
   - shakespeare >=2.0.12 && <2.1
@@ -121,7 +121,7 @@ tests:
   hlint:
     main: lint.hs
     dependencies:
-    - hlint >=2.1.6 && <2.2
+    - hlint >=2.1.7 && <2.2
   spec:
     main: Main.hs
     source-dirs:
@@ -142,7 +142,7 @@ tests:
     - process >=1.1 && <2
     - semigroups
     - string-qq >=0.0.2 && <0.1.0
-    - temporary >=1.2 && <1.3
+    - temporary >=1.2 && <1.4
   targets:
     main: test-targets.hs
     source-dirs: app

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-11.15
+resolver: lts-12.0
 flags: {}
 packages:
 - '.'

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.0
+resolver: lts-12.2
 flags: {}
 packages:
 - '.'

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,7 +4,10 @@ packages:
 - '.'
 extra-deps:
 - uri-0.1.6.4
-  # No in the Stackage LTS 10.7
+  # No in the Stackage LTS 12.0
+- Win32-2.5.4.1
+  # While turtle-1.5.10 requires Win32 >=2.2.0.1 && <2.6 on Windows,
+  # Stackage LTS 12.0 has only Win32-2.6.1.0.
 ## INSERT CODECOV HERE -- DO NOT REMOVE THIS COMMENT. SEE ALSO ISSUE #156. ##
 extra-package-dbs: []
 ghc-options:


### PR DESCRIPTION
- GHC is upgraded from 8.2.2 to 8.4.3.
- A temporary HLint configuration (made by the PR #286) to ignore “Use const” hint due to ndmitchell/hlint#506 is gone as newer HLint version that the bug was fixed is included to `lts-12.0`.